### PR TITLE
fix: workout timer throttling and durationSeconds not persisted

### DIFF
--- a/backend/src/modules/workout/workout.service.ts
+++ b/backend/src/modules/workout/workout.service.ts
@@ -84,6 +84,7 @@ export const updateWorkout = async (
     ...(data.gymName !== undefined && { gymName: data.gymName }),
     ...(data.location !== undefined && { location: data.location }),
     ...(data.workoutNotes !== undefined && { workoutNotes: data.workoutNotes }),
+    ...(data.durationSeconds !== undefined && { durationSeconds: data.durationSeconds }),
   };
 
   const updatedWorkout = await workoutRepo.updateWorkout(id, updateData);

--- a/frontend/src/components/screens/WorkoutDetailScreen.tsx
+++ b/frontend/src/components/screens/WorkoutDetailScreen.tsx
@@ -93,11 +93,10 @@ export function WorkoutDetailScreen({
     if (!workout || workout.status !== "DRAFT") return;
 
     const startedAt = new Date(workout.createdAt).getTime();
-    const initialElapsed = Math.floor((Date.now() - startedAt) / 1000);
-    setElapsed(Math.max(0, initialElapsed));
+    setElapsed(Math.max(0, Math.floor((Date.now() - startedAt) / 1000)));
 
     timerRef.current = setInterval(() => {
-      setElapsed((e) => e + 1);
+      setElapsed(Math.max(0, Math.floor((Date.now() - startedAt) / 1000)));
     }, 1000);
 
     return () => {


### PR DESCRIPTION
## Summary

- **Timer drift** (`WorkoutDetailScreen.tsx`): replaced `setElapsed(e => e + 1)` with wall-clock calculation `Date.now() - startedAt` on every tick — browser throttles `setInterval` in background tabs, causing the counter to lag hours behind real time. Now matches how `WorkoutTimerPill` in `BottomNavigation` already works.
- **"Brak danych" after completing workout** (`workout.service.ts`): `durationSeconds` was accepted by the Zod schema and present in the Prisma model, but was silently dropped in `updateData` and never written to the DB. Added the missing spread to persist it.

## Test plan

- [ ] Start a workout, lock screen / switch tabs for a few minutes, return — timer should show actual elapsed time, not a lagged value
- [ ] Complete a workout, open its detail view — "Czas treningu" should display the real duration instead of "Brak danych"
- [ ] All 28 backend tests pass (`npm test`)
- [ ] Frontend type-check passes (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)