### PR TITLE
chore(seed): merge user-created exercises into seed

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -98,7 +98,7 @@ async function main() {
         creatorUserId: "1",
       },
       {
-        name: "Peck deck (motylek)",
+        name: "Rozpiętki na maszynie",
         muscleGroups: ["CHEST"],
         description: "Izolacja klatki na maszynie",
         creatorUserId: "1",
@@ -171,6 +171,12 @@ async function main() {
         creatorUserId: "1",
       },
       {
+        name: "Wiosłowanie focze hantlami na ławce skośnej",
+        muscleGroups: ["BACK", "MIDDLE_BACK", "LATS"],
+        description: "Seal row - leżąc na ławce skośnej",
+        creatorUserId: "1",
+      },
+      {
         name: "Wiosłowanie T-bar",
         muscleGroups: ["BACK", "MIDDLE_BACK", "TRAPS"],
         description: "Stabilne wiosłowanie na masę",
@@ -207,9 +213,9 @@ async function main() {
         creatorUserId: "1",
       },
       {
-        name: "Prostowanie pleców (hyperextensions)",
+        name: "Wznosy tułowia na ławce rzymskiej",
         muscleGroups: ["LOWER_BACK", "GLUTES", "HAMSTRINGS"],
-        description: "Wzmocnienie dolnej części pleców",
+        description: "Wzmocnienie dolnej części pleców na ławce rzymskiej",
         creatorUserId: "1",
       },
       {
@@ -277,6 +283,12 @@ async function main() {
         name: "Unoszenie na linie bokiem",
         muscleGroups: ["SHOULDERS"],
         description: "Izolacja bocznej części barków",
+        creatorUserId: "1",
+      },
+      {
+        name: "Odwodzenie linki wyciągu jednorącz na tył barku",
+        muscleGroups: ["SHOULDERS"],
+        description: "Izolacja tylnej części barku - jednorącz na wyciągu",
         creatorUserId: "1",
       },
       {
@@ -348,6 +360,12 @@ async function main() {
         creatorUserId: "1",
       },
       {
+        name: "Prostowanie ramion na wyciągu z liną",
+        muscleGroups: ["TRICEPS"],
+        description: "Wariant z liną - większy zakres ruchu",
+        creatorUserId: "1",
+      },
+      {
         name: "Wyciskanie francuskie sztangą",
         muscleGroups: ["TRICEPS"],
         description: "Leżąc - rozciąga tricepsy",
@@ -403,6 +421,12 @@ async function main() {
         creatorUserId: "1",
       },
       {
+        name: "Przysiad sumo",
+        muscleGroups: ["QUADS", "GLUTES", "ADDUCTORS"],
+        description: "Przysiad z szerszym rozstawieniem nóg",
+        creatorUserId: "1",
+      },
+      {
         name: "Wypychanie nóg na suwnicy",
         muscleGroups: ["QUADS", "GLUTES", "HAMSTRINGS"],
         description: "Bezpieczna alternatywa dla przysiadów",
@@ -454,6 +478,12 @@ async function main() {
         name: "Mostek biodrowy",
         muscleGroups: ["GLUTES", "HAMSTRINGS"],
         description: "Wariant bez obciążenia",
+        creatorUserId: "1",
+      },
+      {
+        name: "Glute bridge",
+        muscleGroups: ["GLUTES"],
+        description: "Izolowane spięcie pośladków leżąc",
         creatorUserId: "1",
       },
       {


### PR DESCRIPTION
## Summary
- Aligns `prisma/seed.ts` with the manual cleanup applied to the live database (5 merges + 4 promotions + 1 deletion of stray user-created exercises).
- After this change a fresh `npx prisma db seed` on an empty database produces the same **107 global exercises** as production.
- No schema changes, no migrations — only seed data.

## Changes in `backend/prisma/seed.ts`

**Renamed (existing seed rows):**
- `Peck deck (motylek)` → `Rozpiętki na maszynie`
- `Prostowanie pleców (hyperextensions)` → `Wznosy tułowia na ławce rzymskiej` (description tweaked accordingly)

**Added (previously created by users, promoted to global):**
| Name | Muscle groups |
|---|---|
| Wiosłowanie focze hantlami na ławce skośnej | BACK, MIDDLE_BACK, LATS |
| Odwodzenie linki wyciągu jednorącz na tył barku | SHOULDERS |
| Prostowanie ramion na wyciągu z liną | TRICEPS |
| Przysiad sumo | QUADS, GLUTES, ADDUCTORS |
| Glute bridge | GLUTES |

All new entries use `creatorUserId: "1"` (the seed/admin user), consistent with the rest of the seed.

## Context
The live DB previously had 12 user-created exercise rows with typos, duplicates, and inconsistent muscle groups. These were consolidated via SQL (renames, 3-way merges into existing seed rows, repointing of `workout_items` / `exercise_user_stats` / `exercise_pending_notes`). This PR records the new canonical list in the seed so the two stay in sync.

## Test plan
- [ ] `cd backend && npx tsc --noEmit prisma/seed.ts` passes (already verified locally)
- [ ] `grep -c '^        name:' backend/prisma/seed.ts` returns `107`
- [ ] On a fresh local DB: `npx prisma migrate reset && npx prisma db seed` succeeds and creates 107 exercises
- [ ] Spot-check that the 5 newly added names appear in `GET /api/exercises` for any logged-in user