### PR TITLE
chore(ui): workout timer polish — remove emoji, stabilize pill width

### DIFF
--- a/frontend/src/components/screens/TrainingsScreen.tsx
+++ b/frontend/src/components/screens/TrainingsScreen.tsx
@@ -66,7 +66,7 @@ const WorkoutCard = memo(function WorkoutCard({
         )}
         {workout.durationSeconds != null && (
           <div className="text-[11px] mt-0.5" style={{ color: "var(--gg-text-muted)" }}>
-            ⏱ {formatDuration(workout.durationSeconds)}
+            {formatDuration(workout.durationSeconds)}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
Two small UI fixes around the workout-timer display:

1. **Trainings list:** removed the `⏱` emoji that prefixed `durationSeconds` in each entry — the duration value now stands on its own.
2. **WorkoutTimerPill (bottom nav):** the pill no longer resizes as the elapsed time updates. `tabular-nums` alone wasn't enough with the Barlow font, so the time `<span>` is now `inline-block` with `min-width: 5ch` and centered text — width stays constant for any `MM:SS`.

## Files
- `frontend/src/components/screens/TrainingsScreen.tsx`
- `frontend/src/components/navigation/BottomNavigation.tsx`

## Test plan
- [ ] Workouts list: entries with `durationSeconds` show only the duration text (no stopwatch icon).
- [ ] Start a workout and watch the bottom-right pill update second-by-second — its outer width does not change.
- [ ] Verify the pill still looks right when the timer rolls past 9:59 → 10:00 and (edge case) 99:59 → 100:00.