### PR TITLE
fix: exercise selection modal full-screen in PlanFormScreen

### DIFF
--- a/frontend/src/components/screens/PlanFormScreen.tsx
+++ b/frontend/src/components/screens/PlanFormScreen.tsx
@@ -225,7 +225,8 @@ export const PlanFormScreen = memo(function PlanFormScreen({
   const existingIds = items.map((i) => i.exerciseId);
 
   return (
-    <div className="px-5 pt-5 screen-enter">
+    <>
+      <div className="px-5 pt-5 screen-enter">
       {/* Header */}
       <div className="flex items-center gap-3 mb-6">
         <button
@@ -398,7 +399,8 @@ export const PlanFormScreen = memo(function PlanFormScreen({
         </button>
       </div>
 
-      {/* Exercise selection modal */}
+      </div>
+
       {showExerciseModal && (
         <ExerciseSelectionModal
           onClose={() => setShowExerciseModal(false)}
@@ -407,6 +409,6 @@ export const PlanFormScreen = memo(function PlanFormScreen({
           onCreateNewExercise={onCreateNewExercise}
         />
       )}
-    </div>
+    </>
   );
 });


### PR DESCRIPTION
The screen-enter CSS animation sets transform: translateY(0) via its
forwards fill, creating a new CSS containing block on the root div.
Any position:absolute child is then clamped to that div's height
instead of the phone-frame, making the modal appear as ~1/3 screen.

Fix mirrors WorkoutDetailScreen: return a Fragment and render
ExerciseSelectionModal as a sibling of the animated div so it
positions relative to the phone-frame as intended.

Closes #60