### PR TITLE
feat: draft-based set UX — eliminacja phantom records (#65)

### DIFF
--- a/frontend/src/components/screens/WorkoutDetailScreen.tsx
+++ b/frontend/src/components/screens/WorkoutDetailScreen.tsx
@@ -337,17 +337,9 @@ export function WorkoutDetailScreen({
   };
 
   const handleAddSet = useCallback(
-    async (itemId: string) => {
-      const currentWorkout = workoutRef.current;
-      if (!currentWorkout) return;
-      const item = currentWorkout.items.find((i) => i.id === itemId);
-      if (!item) return;
-      const lastSet = item.sets[item.sets.length - 1];
-      const nextSetNumber = lastSet ? lastSet.setNumber + 1 : 1;
-      const defaultWeight = lastSet ? Math.max(Number(lastSet.weight), 1) : 1;
-      const defaultReps = lastSet ? lastSet.repetitions : 10;
+    async (itemId: string, data: { weight: number; repetitions: number; setNumber: number }) => {
       try {
-        await addSet(itemId, { weight: defaultWeight, repetitions: defaultReps, setNumber: nextSetNumber });
+        await addSet(itemId, data);
       } catch (error) {
         if (error instanceof WorkoutNotFoundError) {
           onBack();
@@ -763,22 +755,38 @@ function SetRowEditable({
   onSave: (setId: string, data: { weight?: number; repetitions?: number }) => void;
   onDelete: (itemId: string, setId: string) => void;
 }) {
+  const [isEditing, setIsEditing] = useState(false);
   const [weight, setWeight] = useState(set.weight);
   const [reps, setReps] = useState(set.repetitions.toString());
+  const [editError, setEditError] = useState<string | null>(null);
 
   useEffect(() => {
-    setWeight(set.weight);
-    setReps(set.repetitions.toString());
-  }, [set.weight, set.repetitions]);
+    if (!isEditing) {
+      setWeight(set.weight);
+      setReps(set.repetitions.toString());
+    }
+  }, [set.weight, set.repetitions, isEditing]);
 
-  const handleSave = () => {
+  const handleAccept = () => {
     const nextWeight = Number(weight);
     const nextReps = Number(reps);
-    if (nextWeight < 0 || nextReps < 1 || isNaN(nextWeight) || isNaN(nextReps)) return;
+    if (isNaN(nextWeight) || isNaN(nextReps) || nextWeight < 0 || nextReps < 1) {
+      setEditError("Podaj prawidłowe wartości (kg ≥ 0, powt. ≥ 1)");
+      return;
+    }
+    setEditError(null);
     const payload: { weight?: number; repetitions?: number } = {};
     if (nextWeight !== Number(set.weight)) payload.weight = nextWeight;
     if (nextReps !== set.repetitions) payload.repetitions = nextReps;
     if (Object.keys(payload).length > 0) onSave(set.id, payload);
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setWeight(set.weight);
+    setReps(set.repetitions.toString());
+    setEditError(null);
+    setIsEditing(false);
   };
 
   const handleDelete = () => {
@@ -787,53 +795,190 @@ function SetRowEditable({
     }
   };
 
+  const rowBg = { padding: "10px 10px", background: "var(--gg-surface2)" };
+  const inputStyle = { padding: "8px 6px", background: "var(--gg-surface3)", border: "1.5px solid var(--gg-border)", color: "var(--gg-text)", outline: "none" };
+
+  if (isEditing) {
+    return (
+      <div className="flex flex-col gap-1 w-full rounded-[10px]" style={rowBg}>
+        <div className="flex items-center gap-2 w-full">
+          <span className="text-[12px] font-bold w-6 flex-shrink-0 text-center" style={{ color: "var(--gg-text-muted)" }}>
+            #{set.setNumber}
+          </span>
+          <div className="flex items-center gap-1 flex-1 min-w-0">
+            <input
+              type="number"
+              value={weight}
+              onChange={(e) => { setWeight(e.target.value); setEditError(null); }}
+              step="0.5"
+              min="0"
+              autoFocus
+              className="flex-1 min-w-0 rounded-[8px] text-[14px] font-bold text-center"
+              style={inputStyle}
+            />
+            <span className="text-[10px] font-semibold flex-shrink-0" style={{ color: "var(--gg-text-muted)" }}>kg</span>
+          </div>
+          <div className="flex items-center gap-1 flex-1 min-w-0">
+            <input
+              type="number"
+              value={reps}
+              onChange={(e) => { setReps(e.target.value); setEditError(null); }}
+              min="1"
+              className="flex-1 min-w-0 rounded-[8px] text-[14px] font-bold text-center"
+              style={inputStyle}
+            />
+            <span className="text-[10px] font-semibold flex-shrink-0" style={{ color: "var(--gg-text-muted)" }}>powt.</span>
+          </div>
+          <button
+            onClick={handleAccept}
+            className="w-9 h-9 rounded-[9px] border-none cursor-pointer flex items-center justify-center flex-shrink-0"
+            style={{ background: "var(--gg-a1)" }}
+          >
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M5 12l5 5 9-9"/>
+            </svg>
+          </button>
+          <button
+            onClick={handleCancel}
+            className="w-9 h-9 rounded-[9px] border-none cursor-pointer flex items-center justify-center flex-shrink-0"
+            style={{ background: "var(--gg-surface3)" }}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--gg-text-muted)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18"/>
+              <line x1="6" y1="6" x2="18" y2="18"/>
+            </svg>
+          </button>
+        </div>
+        {editError && (
+          <p className="text-[11px] text-center" style={{ color: "var(--gg-danger, #ef4444)" }}>{editError}</p>
+        )}
+      </div>
+    );
+  }
+
   return (
-    <div className="flex items-center gap-2 w-full rounded-[10px]" style={{ padding: "10px 10px", background: "var(--gg-surface2)" }}>
+    <div className="flex items-center gap-2 w-full rounded-[10px]" style={rowBg}>
       <span className="text-[12px] font-bold w-6 flex-shrink-0 text-center" style={{ color: "var(--gg-text-muted)" }}>
         #{set.setNumber}
       </span>
-      <div className="flex-1 min-w-0 flex flex-col gap-0.5">
-        <input
-          type="number"
-          value={weight}
-          onChange={(e) => setWeight(e.target.value)}
-          step="0.5"
-          min="0"
-          className="w-full rounded-[8px] text-[14px] font-bold text-center"
-          style={{ padding: "8px 6px", background: "var(--gg-surface3)", border: "1.5px solid var(--gg-border)", color: "var(--gg-text)", outline: "none" }}
-        />
-        <span className="text-[10px] font-semibold text-center" style={{ color: "var(--gg-text-muted)" }}>kg</span>
-      </div>
-      <div className="flex-1 min-w-0 flex flex-col gap-0.5">
-        <input
-          type="number"
-          value={reps}
-          onChange={(e) => setReps(e.target.value)}
-          min="1"
-          className="w-full rounded-[8px] text-[14px] font-bold text-center"
-          style={{ padding: "8px 6px", background: "var(--gg-surface3)", border: "1.5px solid var(--gg-border)", color: "var(--gg-text)", outline: "none" }}
-        />
-        <span className="text-[10px] font-semibold text-center" style={{ color: "var(--gg-text-muted)" }}>powt.</span>
-      </div>
+      <span className="flex-1 text-[13px]" style={{ color: "var(--gg-text)" }}>
+        <strong>{set.weight}</strong> <span style={{ color: "var(--gg-text-muted)" }}>kg ×</span> <strong>{set.repetitions}</strong> <span style={{ color: "var(--gg-text-muted)" }}>powt.</span>
+      </span>
       <button
-        onClick={handleSave}
+        onClick={() => setIsEditing(true)}
         className="w-9 h-9 rounded-[9px] border-none cursor-pointer flex items-center justify-center flex-shrink-0"
-        style={{ background: "var(--gg-a1)" }}
+        style={{ background: "var(--gg-surface3)" }}
+        title="Edytuj"
       >
-        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M5 12l5 5 9-9"/>
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="var(--gg-text-muted)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+          <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
         </svg>
       </button>
       <button
         onClick={handleDelete}
         className="w-9 h-9 rounded-[9px] border-none cursor-pointer flex items-center justify-center flex-shrink-0"
         style={{ background: "var(--gg-surface3)" }}
+        title="Usuń"
       >
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--gg-text-muted)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-          <line x1="18" y1="6" x2="6" y2="18"/>
-          <line x1="6" y1="6" x2="18" y2="18"/>
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="var(--gg-text-muted)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="3 6 5 6 21 6"/>
+          <path d="M19 6l-1 14H6L5 6M10 11v6M14 11v6M9 6V4h6v2"/>
         </svg>
       </button>
+    </div>
+  );
+}
+
+// ─── DraftSetRow ─────────────────────────────────────────────────────────────
+
+function DraftSetRow({
+  setNumber,
+  defaultWeight,
+  defaultReps,
+  onConfirm,
+  onCancel,
+}: {
+  setNumber: number;
+  defaultWeight: string;
+  defaultReps: string;
+  onConfirm: (weight: number, reps: number) => void;
+  onCancel: () => void;
+}) {
+  const [weight, setWeight] = useState(defaultWeight);
+  const [reps, setReps] = useState(defaultReps);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleConfirm = () => {
+    const w = Number(weight);
+    const r = Number(reps);
+    if (isNaN(w) || isNaN(r) || w < 0 || r < 1) {
+      setError("Podaj prawidłowe wartości (kg ≥ 0, powt. ≥ 1)");
+      return;
+    }
+    onConfirm(w, r);
+  };
+
+  const inputStyle = { padding: "8px 6px", background: "var(--gg-surface3)", border: "1.5px solid var(--gg-a1)", color: "var(--gg-text)", outline: "none" };
+
+  return (
+    <div
+      className="flex flex-col gap-1 w-full rounded-[10px]"
+      style={{ padding: "10px 10px", background: "var(--gg-surface2)", border: "1.5px solid var(--gg-a1)" }}
+    >
+      <div className="flex items-center gap-2 w-full">
+        <span className="text-[12px] font-bold w-6 flex-shrink-0 text-center" style={{ color: "var(--gg-a1)" }}>
+          #{setNumber}
+        </span>
+        <div className="flex items-center gap-1 flex-1 min-w-0">
+          <input
+            type="number"
+            value={weight}
+            onChange={(e) => { setWeight(e.target.value); setError(null); }}
+            step="0.5"
+            min="0"
+            autoFocus
+            className="flex-1 min-w-0 rounded-[8px] text-[14px] font-bold text-center"
+            style={inputStyle}
+          />
+          <span className="text-[10px] font-semibold flex-shrink-0" style={{ color: "var(--gg-text-muted)" }}>kg</span>
+        </div>
+        <div className="flex items-center gap-1 flex-1 min-w-0">
+          <input
+            type="number"
+            value={reps}
+            onChange={(e) => { setReps(e.target.value); setError(null); }}
+            min="1"
+            className="flex-1 min-w-0 rounded-[8px] text-[14px] font-bold text-center"
+            style={inputStyle}
+          />
+          <span className="text-[10px] font-semibold flex-shrink-0" style={{ color: "var(--gg-text-muted)" }}>powt.</span>
+        </div>
+        <button
+          onClick={handleConfirm}
+          className="w-9 h-9 rounded-[9px] border-none cursor-pointer flex items-center justify-center flex-shrink-0"
+          style={{ background: "var(--gg-a1)" }}
+          title="Zatwierdź"
+        >
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M5 12l5 5 9-9"/>
+          </svg>
+        </button>
+        <button
+          onClick={onCancel}
+          className="w-9 h-9 rounded-[9px] border-none cursor-pointer flex items-center justify-center flex-shrink-0"
+          style={{ background: "var(--gg-surface3)" }}
+          title="Anuluj"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--gg-text-muted)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18"/>
+            <line x1="6" y1="6" x2="18" y2="18"/>
+          </svg>
+        </button>
+      </div>
+      {error && (
+        <p className="text-[11px] text-center" style={{ color: "var(--gg-danger, #ef4444)" }}>{error}</p>
+      )}
     </div>
   );
 }
@@ -852,7 +997,7 @@ interface WorkoutItemCardProps {
   onToggleExpand: (itemId: string) => void;
   onUpdateSet: (setId: string, data: { weight?: number; repetitions?: number }) => void;
   onDeleteSet: (itemId: string, setId: string) => void;
-  onAddSet: (itemId: string) => void;
+  onAddSet: (itemId: string, data: { weight: number; repetitions: number; setNumber: number }) => void;
   onDeleteExercise: (itemId: string) => void;
   onUpdateExerciseNotes: (itemId: string, notes: string) => Promise<void>;
 }
@@ -877,6 +1022,7 @@ const WorkoutItemCard = memo(
     const [isEditingNotes, setIsEditingNotes] = useState(false);
     const [editNotesValue, setEditNotesValue] = useState(item.notes ?? "");
     const [displayedNotes, setDisplayedNotes] = useState(item.notes ?? "");
+    const [draftSet, setDraftSet] = useState<{ weight: string; reps: string } | null>(null);
 
     const canEdit = !isCompleted || isEditMode;
     const noteToDisplay = lastExerciseNote;
@@ -888,6 +1034,10 @@ const WorkoutItemCard = memo(
     useEffect(() => {
       setDisplayedNotes(item.notes ?? "");
     }, [item.notes]);
+
+    useEffect(() => {
+      if (!isExpanded) setDraftSet(null);
+    }, [isExpanded]);
 
     const handleSaveExerciseNotes = async () => {
       const notes = editNotesValue.trim();
@@ -1004,7 +1154,7 @@ const WorkoutItemCard = memo(
             )}
 
             {/* Sets */}
-            {item.sets.length === 0 ? (
+            {item.sets.length === 0 && !draftSet ? (
               <p className="text-[13px] mb-3" style={{ color: "var(--gg-text-muted)" }}>
                 Brak serii. Dodaj pierwszą serię poniżej.
               </p>
@@ -1034,6 +1184,18 @@ const WorkoutItemCard = memo(
                     </div>
                   ),
                 )}
+                {draftSet && canEdit && (
+                  <DraftSetRow
+                    setNumber={item.sets.length + 1}
+                    defaultWeight={draftSet.weight}
+                    defaultReps={draftSet.reps}
+                    onConfirm={(w, r) => {
+                      onAddSet(item.id, { weight: w, repetitions: r, setNumber: item.sets.length + 1 });
+                      setDraftSet(null);
+                    }}
+                    onCancel={() => setDraftSet(null)}
+                  />
+                )}
               </div>
             )}
 
@@ -1041,8 +1203,16 @@ const WorkoutItemCard = memo(
             {canEdit && (
               <div className="grid grid-cols-2 gap-2">
                 <button
-                  onClick={() => onAddSet(item.id)}
-                  className="py-2.5 rounded-[12px] text-[13px] font-bold cursor-pointer"
+                  onClick={() => {
+                    if (draftSet) return;
+                    const lastSet = item.sets[item.sets.length - 1];
+                    setDraftSet({
+                      weight: lastSet ? String(Math.max(Number(lastSet.weight), 0)) : "0",
+                      reps: lastSet ? String(lastSet.repetitions) : "10",
+                    });
+                  }}
+                  disabled={!!draftSet}
+                  className="py-2.5 rounded-[12px] text-[13px] font-bold cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
                   style={{
                     border: "2px dashed var(--gg-a1)",
                     color: "var(--gg-a1)",


### PR DESCRIPTION
## Summary

- **SetRowEditable** zyskał dwa tryby: *widok* (przyciski Edytuj / Usuń) i *edycja* (inputy + Akceptuj / Anuluj). Serie nie są już domyślnie edytowalne od razu po wyrenderowaniu.
- **DraftSetRow** — nowy komponent szkicu: nowa seria pojawia się lokalnie i trafia do DB dopiero po kliknięciu Zatwierdź. Anuluj usuwa wiersz bez żadnego żądania do API.
- **Walidacja inline** — gdy wartości kg/powt. są nieprawidłowe, pod polami pojawia się komunikat błędu (zamiast cichego `return`). Błąd znika po edycji pola.
- **Reset draftu przy collapse** — `draftSet` jest czyszczony gdy karta ćwiczenia zostaje zwinięta.
- **Blokada wielokrotnych draftów** — przycisk `+ Dodaj serię` jest `disabled` (opacity-40) gdy draft jest aktywny.
- **Poprawka wyrównania** — etykiety `kg` i `powt.` przeniesione z `flex-col` pod input na inline obok inputa; przyciski wyrównują się teraz do środka inputa.

## Test plan

- [ ] Dodaj serię → pojawia się DraftSetRow z wartościami z ostatniej serii
- [ ] Zatwierdź → seria pojawia się na liście i trafia do DB
- [ ] Anuluj → wiersz znika, brak nowego rekordu w DB
- [ ] Podaj reps = 0 i kliknij Zatwierdź → pojawia się komunikat błędu
- [ ] Kliknij Edytuj na istniejącej serii → wejście w tryb edycji z inputami
- [ ] Zmień wartości i kliknij Akceptuj → rekord zaktualizowany w DB
- [ ] Kliknij Anuluj w edycji → wartości przywrócone, brak zapisu
- [ ] Otwórz draft, zwiń ćwiczenie, rozwiń ponownie → brak draftu
- [ ] Podczas aktywnego draftu przycisk `+ Dodaj serię` jest wyszarzony

🤖 Generated with [Claude Code](https://claude.com/claude-code)