### PR TITLE
feat: stale workout detection and editable start/end time

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigation, useTheme } from "./hooks";
 import type { Theme } from "./hooks/useTheme";
 import { useAuth } from "./contexts/AuthContext";
 import { useData } from "./contexts/DataContext";
-import type { TabType, Screen } from "@/types";
+import type { TabType, Screen, Workout } from "@/types";
 import {
   MainLayout,
   BottomNavigation,
@@ -25,6 +25,19 @@ import { RegisterScreen } from "./components/screens/RegisterScreen";
 import type { Exercise } from "./hooks/useExercises";
 import type { WorkoutPlan } from "./types";
 import type { SyncOperation } from "./utils/localStore";
+
+const STALE_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours
+
+function computeLastActivity(workout: Workout): number {
+  let latest = new Date(workout.updatedAt).getTime();
+  for (const item of workout.items) {
+    latest = Math.max(latest, new Date(item.updatedAt).getTime());
+    for (const set of item.sets) {
+      latest = Math.max(latest, new Date(set.updatedAt).getTime());
+    }
+  }
+  return latest;
+}
 
 const ENTITY_LABELS: Record<SyncOperation["entity"], string> = {
   workout: "treningu",
@@ -211,12 +224,16 @@ function AuthenticatedApp({
     updateExercise,
     activeWorkoutId,
     getWorkout,
+    completeWorkout,
+    isLoading,
     failedSyncOperations,
     dismissSyncFailures,
     syncNow,
   } = useData();
   const [isWorkoutFormOpen, setIsWorkoutFormOpen] = useState(false);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [staleWorkout, setStaleWorkout] = useState<Workout | null>(null);
+  const staleCheckDone = useRef(new Set<string>());
 
   useEffect(() => {
     if (
@@ -229,11 +246,43 @@ function AuthenticatedApp({
     }
   }, [screen, selectedWorkoutId, getWorkout, setScreen, setSelectedWorkoutId]);
 
+  useEffect(() => {
+    if (isLoading || !activeWorkoutId) return;
+    if (staleCheckDone.current.has(activeWorkoutId)) return;
+
+    const workout = getWorkout(activeWorkoutId);
+    if (!workout || workout.status === "COMPLETED") return;
+
+    staleCheckDone.current.add(activeWorkoutId);
+
+    const lastActivity = computeLastActivity(workout);
+    if (Date.now() - lastActivity > STALE_THRESHOLD_MS) {
+      setStaleWorkout(workout);
+    }
+  }, [activeWorkoutId, isLoading, getWorkout]);
+
   const activeWorkout = activeWorkoutId ? getWorkout(activeWorkoutId) : null;
   const workoutStartedAt =
     activeWorkout && activeWorkout.status !== "COMPLETED"
       ? activeWorkout.createdAt
       : null;
+
+  const handleCompleteStaleWorkout = async () => {
+    if (!staleWorkout) return;
+    const lastActivity = computeLastActivity(staleWorkout);
+    const durationSeconds = Math.max(
+      0,
+      Math.floor((lastActivity - new Date(staleWorkout.createdAt).getTime()) / 1000),
+    );
+    try {
+      await completeWorkout(staleWorkout.id, durationSeconds);
+    } catch {
+      // intentionally silent — workout remains DRAFT if completion fails
+    }
+    setStaleWorkout(null);
+  };
+
+  const handleDismissStaleWorkout = () => setStaleWorkout(null);
 
   const handleAddWorkoutClick = () => {
     if (activeWorkout && activeWorkout.status !== "COMPLETED") {
@@ -456,6 +505,71 @@ function AuthenticatedApp({
           onSubmit={handleCreateWorkout}
         />
       )}
+
+      {staleWorkout && (() => {
+        const lastActivity = computeLastActivity(staleWorkout);
+        const diffMs = Date.now() - lastActivity;
+        const hoursAgo = Math.floor(diffMs / (60 * 60 * 1000));
+        const minutesAgo = Math.floor((diffMs % (60 * 60 * 1000)) / (60 * 1000));
+        const timeLabel = hoursAgo > 0
+          ? `${hoursAgo}h ${minutesAgo}min`
+          : `${minutesAgo} min`;
+
+        return (
+          <div
+            className="fixed inset-0 z-50 flex items-end justify-center pb-8 px-4"
+            style={{ background: "rgba(0,0,0,0.55)", backdropFilter: "blur(4px)" }}
+          >
+            <div
+              className="w-full max-w-sm rounded-[22px] p-5"
+              style={{
+                background: "var(--gg-surface)",
+                border: "1.5px solid var(--gg-border)",
+                boxShadow: "0 16px 48px rgba(0,0,0,0.5)",
+              }}
+            >
+              <div className="flex items-center gap-3 mb-3">
+                <div
+                  className="flex items-center justify-center rounded-full flex-shrink-0"
+                  style={{ width: 36, height: 36, background: "var(--gg-active-bg)", border: "1.5px solid var(--gg-active-border)" }}
+                >
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--gg-active-border)" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                    <circle cx="12" cy="12" r="10"/>
+                    <polyline points="12 6 12 12 16 14"/>
+                  </svg>
+                </div>
+                <div>
+                  <p className="text-[14px] font-bold" style={{ color: "var(--gg-text)" }}>Trening się skończył?</p>
+                  <p className="text-[12px]" style={{ color: "var(--gg-text-muted)" }}>
+                    Ostatnia aktywność {timeLabel} temu
+                  </p>
+                </div>
+              </div>
+              {staleWorkout.workoutName && (
+                <p className="text-[13px] mb-3" style={{ color: "var(--gg-text-sub)" }}>
+                  {staleWorkout.workoutName}
+                </p>
+              )}
+              <div className="flex gap-2 mt-4">
+                <button
+                  onClick={handleDismissStaleWorkout}
+                  className="flex-1 py-2.5 rounded-xl text-[13px] font-bold cursor-pointer"
+                  style={{ background: "var(--gg-surface2)", border: "1.5px solid var(--gg-border)", color: "var(--gg-text-sub)" }}
+                >
+                  Kontynuuj
+                </button>
+                <button
+                  onClick={handleCompleteStaleWorkout}
+                  className="flex-1 py-2.5 rounded-xl text-[13px] font-bold cursor-pointer text-white border-none"
+                  style={{ background: "var(--gg-grad-btn)", boxShadow: "0 3px 14px var(--gg-glow)" }}
+                >
+                  Zakończ trening
+                </button>
+              </div>
+            </div>
+          </div>
+        );
+      })()}
     </MainLayout>
   );
 }

--- a/frontend/src/components/screens/WorkoutDetailScreen.tsx
+++ b/frontend/src/components/screens/WorkoutDetailScreen.tsx
@@ -64,6 +64,8 @@ export function WorkoutDetailScreen({
   const [editGymName, setEditGymName] = useState("");
   const [editWorkoutDate, setEditWorkoutDate] = useState("");
   const [editWorkoutNotes, setEditWorkoutNotes] = useState("");
+  const [editStartTime, setEditStartTime] = useState("");
+  const [editEndTime, setEditEndTime] = useState("");
 
   // Timer state — seconds elapsed since workout was created
   const [elapsed, setElapsed] = useState(0);
@@ -281,19 +283,40 @@ export function WorkoutDetailScreen({
     const month = String(date.getMonth() + 1).padStart(2, "0");
     const day = String(date.getDate()).padStart(2, "0");
     setEditWorkoutDate(`${year}-${month}-${day}`);
+
+    const startDate = new Date(workout!.workoutDate);
+    setEditStartTime(`${String(startDate.getHours()).padStart(2, "0")}:${String(startDate.getMinutes()).padStart(2, "0")}`);
+
+    const endMs = startDate.getTime() + (workout!.durationSeconds || 0) * 1000;
+    const endDate = new Date(endMs);
+    setEditEndTime(`${String(endDate.getHours()).padStart(2, "0")}:${String(endDate.getMinutes()).padStart(2, "0")}`);
+
     setIsEditMode(true);
   };
+
+  const editedDurationSeconds = useMemo(() => {
+    if (!editStartTime || !editEndTime || !editWorkoutDate) return null;
+    const [year, month, day] = editWorkoutDate.split("-").map(Number);
+    const [startH, startM] = editStartTime.split(":").map(Number);
+    const [endH, endM] = editEndTime.split(":").map(Number);
+    const startDate = new Date(year, month - 1, day, startH, startM, 0, 0);
+    const endDate = new Date(year, month - 1, day, endH, endM, 0, 0);
+    if (endDate <= startDate) endDate.setDate(endDate.getDate() + 1);
+    const seconds = Math.floor((endDate.getTime() - startDate.getTime()) / 1000);
+    return seconds > 0 ? seconds : null;
+  }, [editStartTime, editEndTime, editWorkoutDate]);
 
   const handleSaveCompletedEdits = async () => {
     try {
       const [year, month, day] = editWorkoutDate.split("-").map(Number);
-      const dateObj = new Date(workout!.workoutDate);
-      dateObj.setFullYear(year, month - 1, day);
+      const [startH, startM] = (editStartTime || "00:00").split(":").map(Number);
+      const startDate = new Date(year, month - 1, day, startH, startM, 0, 0);
       await updateWorkout({
-        workoutName: editWorkoutName.trim() || null,
-        gymName: editGymName.trim() || null,
-        workoutDate: dateObj.toISOString(),
-        workoutNotes: editWorkoutNotes.trim() || null,
+        workoutName: editWorkoutName.trim() || undefined,
+        gymName: editGymName.trim() || undefined,
+        workoutDate: startDate.toISOString(),
+        workoutNotes: editWorkoutNotes.trim() || undefined,
+        ...(editedDurationSeconds !== null && { durationSeconds: editedDurationSeconds }),
       });
       setIsEditMode(false);
     } catch (error) {
@@ -594,6 +617,13 @@ export function WorkoutDetailScreen({
                   <span className="text-[13px]" style={{ color: "var(--gg-text-muted)" }}>Czas treningu</span>
                   <span className="text-[13px] font-bold" style={{ color: "var(--gg-a2)" }}>{fmtDuration(workout.durationSeconds)}</span>
                 </div>
+                <div className="flex justify-between items-center mb-2">
+                  <span className="text-[13px]" style={{ color: "var(--gg-text-muted)" }}>Godzina</span>
+                  <span className="text-[13px] font-bold" style={{ color: "var(--gg-text)" }}>
+                    {new Date(workout.workoutDate).toLocaleTimeString("pl-PL", { hour: "2-digit", minute: "2-digit" })}
+                    {workout.durationSeconds ? ` – ${new Date(new Date(workout.workoutDate).getTime() + workout.durationSeconds * 1000).toLocaleTimeString("pl-PL", { hour: "2-digit", minute: "2-digit" })}` : ""}
+                  </span>
+                </div>
                 <div className="flex justify-between items-center">
                   <span className="text-[13px]" style={{ color: "var(--gg-text-muted)" }}>Data</span>
                   <span className="text-[13px] font-bold" style={{ color: "var(--gg-text)" }}>{fmtDate(workout.workoutDate)}</span>
@@ -641,6 +671,23 @@ export function WorkoutDetailScreen({
                 <div>
                   <label className="block text-[12px] font-bold uppercase tracking-wide mb-1.5" style={{ color: "var(--gg-text-sub)" }}>Notatki</label>
                   <textarea value={editWorkoutNotes} onChange={(e) => setEditWorkoutNotes(e.target.value)} placeholder="Dodaj notatki do treningu..." rows={3} style={{ ...inputStyle, resize: "none" }} />
+                </div>
+                <div>
+                  <div className="flex gap-2">
+                    <div className="flex-1">
+                      <label className="block text-[12px] font-bold uppercase tracking-wide mb-1.5" style={{ color: "var(--gg-text-sub)" }}>Rozpoczęcie</label>
+                      <input type="time" value={editStartTime} onChange={(e) => setEditStartTime(e.target.value)} style={inputStyle} />
+                    </div>
+                    <div className="flex-1">
+                      <label className="block text-[12px] font-bold uppercase tracking-wide mb-1.5" style={{ color: "var(--gg-text-sub)" }}>Zakończenie</label>
+                      <input type="time" value={editEndTime} onChange={(e) => setEditEndTime(e.target.value)} style={inputStyle} />
+                    </div>
+                  </div>
+                  {editedDurationSeconds !== null && (
+                    <p className="text-[12px] mt-1.5 font-semibold" style={{ color: "var(--gg-a2)" }}>
+                      Czas treningu: {fmtDuration(editedDurationSeconds)}
+                    </p>
+                  )}
                 </div>
                 <div className="flex gap-2 mt-1">
                   <button onClick={() => setIsEditMode(false)} className="flex-1 py-2.5 rounded-xl text-sm font-bold cursor-pointer" style={{ background: "var(--gg-surface2)", border: "1.5px solid var(--gg-border)", color: "var(--gg-text-sub)" }}>Anuluj</button>

--- a/plans/2026-05-17_15-00_stale-workout-detection.md
+++ b/plans/2026-05-17_15-00_stale-workout-detection.md
@@ -1,0 +1,28 @@
+# Plan: Stale Workout Detection + Editable End Time
+
+## Problem
+Timer liczy czas od `workout.createdAt`. Gdy trening zostanie jako DRAFT przez wiele godzin
+(np. użytkownik zapomniał zakończyć), timer pokazuje 11+ godzin przy kolejnym otwarciu apki.
+
+## Rozwiązanie
+
+### Część 1: Stale Workout Detection — `App.tsx`
+- Próg: 2h nieaktywności (max z updatedAt treningu/ćwiczeń/serii)
+- Gdy `!isLoading && activeWorkoutId` i trening jest DRAFT > 2h stary → dialog
+- Dialog: "Nie było aktywności od X godz. Czy zakończyć trening?"
+- "Zakończ" → `completeWorkout(id, lastActivity - createdAt)`
+- "Kontynuuj" → dismiss (raz na sesję, via `staleCheckDone` ref)
+
+### Część 2: Edytowalne pole końca treningu — `WorkoutDetailScreen.tsx`
+- W trybie edycji COMPLETED treningu: nowe pole `type="time"` "Godzina zakończenia"
+- Inicjalizacja: `createdAt + durationSeconds`
+- Live preview: "Czas treningu: Xh Ymin" (live update przy zmianie godziny)
+- Zapis: `durationSeconds = endTime - createdAt`
+
+## Pliki
+1. `frontend/src/App.tsx` — ~90 linii dodanych
+2. `frontend/src/components/screens/WorkoutDetailScreen.tsx` — ~36 linii dodanych
+
+## Status
+- [ ] App.tsx — stale detection + dialog
+- [ ] WorkoutDetailScreen.tsx — editable end time


### PR DESCRIPTION
## Summary

- Wykrywanie nieaktywnego DRAFT treningu — jeśli użytkownik nie dodał ćwiczenia/serii przez ponad 2h, aplikacja pyta przy otwarciu czy zakończyć trening (z wyliczonym czasem trwania)
- Edytowalne godziny rozpoczęcia i zakończenia w widoku zakończonego treningu, z podglądem czasu trwania na żywo
- Wyświetlanie zakresu godzin (np. "16:00 – 17:15") w widoku COMPLETED treningu
- Fix: walidacja — pola opcjonalne (workoutName, gymName, workoutNotes) wysyłają `undefined` zamiast `null` w żądaniu PATCH

## Zmienione pliki

- `frontend/src/App.tsx` — detekcja stale workout + dialog (próg 2h, raz na sesję per workoutId)
- `frontend/src/components/screens/WorkoutDetailScreen.tsx` — edytowalne godziny start/end, live preview, fix null→undefined

## Test plan

- [ ] Utwórz trening i pozostaw jako DRAFT przez symulację (ustaw datę na wcześniejszą lub zmień próg w kodzie) — sprawdź czy dialog pojawia się przy otwarciu
- [ ] Kliknij "Zakończ trening" w dialogu — sprawdź czy status zmienia się na COMPLETED z poprawnym czasem trwania
- [ ] Kliknij "Kontynuuj" — sprawdź czy dialog nie pojawia się ponownie w tej samej sesji
- [ ] Wejdź w szczegóły zakończonego treningu → "Edytuj" — sprawdź pola "Rozpoczęcie" i "Zakończenie" oraz live preview
- [ ] Zmień godziny i zapisz — sprawdź czy widok pokazuje poprawny zakres i czas trwania
- [ ] Wyczyść notatki i zapisz — sprawdź czy brak błędu walidacji 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)