### PR TITLE
fix: eliminate phantom default set causing wrong stats (#63, #64)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,11 +89,12 @@ Every module follows strict layering: `routes → controller → service → rep
 ## Add-exercise-to-workout flow
 
 1. Frontend calls `addExerciseToWorkout(workoutId, exerciseId)` from DataContext
-2. Optimistic update: creates a `WorkoutItem` with a temp ID and one temp set (`weight: "0"`, `repetitions: 1`)
-3. Fires `POST /api/workouts/:workoutId/exercises`
-4. Backend: `addExerciseToWorkoutWithPendingNote` (transaction: fetches pending note → creates item with `previousNote` set → deletes pending note)
-5. Backend: `addSetToWorkoutItem(item.id, 0, 1, 1)` – creates the first set with default values
-6. Frontend: remaps temp IDs to real IDs from the server response
+2. Optimistic update: creates a `WorkoutItem` with a temp ID and **empty `sets: []`**
+3. `WorkoutItemCard` auto-opens a `draftSet` pre-filled with `ExerciseUserStats.lastWeight/lastReps` — no set is persisted until the user confirms
+4. Fires `POST /api/workouts/:workoutId/exercises`
+5. Backend: `addExerciseToWorkoutWithPendingNote` (transaction: fetches pending note → creates item with `previousNote` set → deletes pending note)
+6. Backend returns `WorkoutItem` with empty `sets: []` — no default set created
+7. Frontend: remaps temp item ID to real ID from the server response
 
 ## Statistics
 

--- a/backend/src/modules/workout/workout.service.test.ts
+++ b/backend/src/modules/workout/workout.service.test.ts
@@ -245,7 +245,7 @@ describe("workout.service", () => {
     expect(workoutRepo.deleteExerciseStats).toHaveBeenCalledWith("u1", "e2");
   });
 
-  it("addExerciseToWorkout: auto-assigns order and creates default set", async () => {
+  it("addExerciseToWorkout: auto-assigns order without creating a default set", async () => {
     vi.mocked(workoutRepo.findWorkoutById).mockResolvedValue({
       id: "w1",
       userId: "u1",
@@ -270,7 +270,7 @@ describe("workout.service", () => {
       3,
       undefined,
     );
-    expect(workoutRepo.addSetToWorkoutItem).toHaveBeenCalledWith("item-1", 0, 1, 1);
+    expect(workoutRepo.addSetToWorkoutItem).not.toHaveBeenCalled();
     expect(result).toEqual({ id: "item-1", workoutId: "w1" });
   });
 

--- a/backend/src/modules/workout/workout.service.ts
+++ b/backend/src/modules/workout/workout.service.ts
@@ -163,19 +163,6 @@ export const addExerciseToWorkout = async (
     data.notes
   );
 
-  let defaultWeight = 0;
-  let defaultReps = 1;
-  try {
-    const stats = await workoutRepo.getExerciseStats(userId, data.exerciseId);
-    if (stats) {
-      defaultWeight = Number(stats.lastWeight);
-      defaultReps = stats.lastReps;
-    }
-  } catch {
-    // fall through to defaults
-  }
-  await workoutRepo.addSetToWorkoutItem(item.id, defaultWeight, defaultReps, 1);
-
   if (workout.status === "COMPLETED") {
     await rebuildExerciseStatsFromCompletedWorkouts(userId, data.exerciseId);
   }

--- a/docs/modules/workout.md
+++ b/docs/modules/workout.md
@@ -64,13 +64,11 @@ POST /api/workouts/:workoutId/exercises
       1. Pobierz ExercisePendingNote dla (userId, exerciseId)
       2. Utwórz WorkoutItem z previousNote = pending?.note
       3. Usuń ExercisePendingNote
-  ↓ addSetToWorkoutItem(item.id, defaultWeight, defaultReps, 1)
-       defaultWeight/defaultReps = lastWeight/lastReps z ExerciseUserStats (fallback: 0 kg / 1 rep)
   ↓ (jeśli workout.status === "COMPLETED") rebuildExerciseStatsFromCompletedWorkouts(userId, exerciseId)
-  ↓ 201 { data: WorkoutItem z sets[] }
+  ↓ 201 { data: WorkoutItem z sets: [] }
 ```
 
-Po stronie frontendu (`DataContext`) stosowany jest optimistic update: item tworzony jest z `temp_*` ID i jedną serią zanim serwer odeprze odpowiedź.
+Po stronie frontendu (`DataContext`) stosowany jest optimistic update: item tworzony jest z `temp_*` ID i **pustą listą serii** (`sets: []`). Pierwsza seria jest wyłącznie po stronie frontendu — jako `draftSet` w `WorkoutItemCard`, pre-wypełniony wartościami `ExerciseUserStats.lastWeight/lastReps`. Serwer nie tworzy domyślnej serii — eliminuje to problem "phantom default set" w historii ćwiczenia.
 
 ### Zamknięcie treningu
 

--- a/frontend/src/components/screens/WorkoutDetailScreen.tsx
+++ b/frontend/src/components/screens/WorkoutDetailScreen.tsx
@@ -1069,9 +1069,13 @@ const WorkoutItemCard = memo(
     const [isEditingNotes, setIsEditingNotes] = useState(false);
     const [editNotesValue, setEditNotesValue] = useState(item.notes ?? "");
     const [displayedNotes, setDisplayedNotes] = useState(item.notes ?? "");
-    const [draftSet, setDraftSet] = useState<{ weight: string; reps: string } | null>(null);
-
     const canEdit = !isCompleted || isEditMode;
+    const [draftSet, setDraftSet] = useState<{ weight: string; reps: string } | null>(
+      item.sets.length === 0 && canEdit
+        ? { weight: String(stats?.lastWeight ?? 0), reps: String(stats?.lastReps ?? 1) }
+        : null,
+    );
+
     const noteToDisplay = lastExerciseNote;
 
     useEffect(() => {
@@ -1254,8 +1258,12 @@ const WorkoutItemCard = memo(
                     if (draftSet) return;
                     const lastSet = item.sets[item.sets.length - 1];
                     setDraftSet({
-                      weight: lastSet ? String(Math.max(Number(lastSet.weight), 0)) : "0",
-                      reps: lastSet ? String(lastSet.repetitions) : "10",
+                      weight: lastSet
+                        ? String(Math.max(Number(lastSet.weight), 0))
+                        : String(stats?.lastWeight ?? 0),
+                      reps: lastSet
+                        ? String(lastSet.repetitions)
+                        : String(stats?.lastReps ?? 1),
                     });
                   }}
                   disabled={!!draftSet}

--- a/frontend/src/contexts/DataContext.tsx
+++ b/frontend/src/contexts/DataContext.tsx
@@ -1030,19 +1030,13 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
       const shouldRefreshStats =
         workoutsRef.current.find((workout) => workout.id === workoutId)?.status ===
         "COMPLETED";
-      // Tymczasowe ID dla optymistycznej aktualizacji
       const tempItemId = `temp_item_${Date.now()}`;
-      const tempSetId = `temp_set_${Date.now()}`;
 
       // Pobierz exercise z ref (nie z state - żeby nie tworzyć zależności)
       const exercise = exercisesRef.current.find((e) => e.id === exerciseId);
       if (!exercise) throw new Error("Nie znaleziono ćwiczenia");
 
-      const exerciseStat = statsRef.current.find((s) => s.exerciseId === exerciseId);
-      const defaultWeight = exerciseStat?.lastWeight ?? "0";
-      const defaultReps = exerciseStat?.lastReps ?? 1;
-
-      // Optymistyczna aktualizacja - dodaj od razu do UI
+      // Optymistyczna aktualizacja - dodaj od razu do UI, bez serii (pierwsza seria = draftSet w UI)
       const newItem = {
         id: tempItemId,
         workoutId,
@@ -1059,17 +1053,7 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
           description: exercise.description,
           photos: exercise.photos,
         },
-        sets: [
-          {
-            id: tempSetId,
-            itemId: tempItemId,
-            setNumber: 1,
-            weight: defaultWeight,
-            repetitions: defaultReps,
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString(),
-          },
-        ],
+        sets: [],
       };
 
       let updatedWorkout: Workout | null = null;
@@ -1091,7 +1075,6 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
       const syncPayload = {
         exerciseId,
         clientTempItemId: tempItemId,
-        clientTempSetId: tempSetId,
       };
 
       if (realWorkoutId.startsWith("temp_") || !navigator.onLine) {
@@ -1125,10 +1108,6 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
 
         if (result.data) {
           idMappingRef.current.set(tempItemId, result.data.id);
-          const serverSets = result.data.sets || [];
-          if (serverSets[0]) {
-            idMappingRef.current.set(tempSetId, serverSets[0].id);
-          }
 
           let remappedWorkout: Workout | null = null;
           setWorkouts((prev) =>
@@ -1142,15 +1121,6 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
                     ...item,
                     id: result.data.id,
                     previousNote: result.data.previousNote ?? null,
-                    sets: item.sets.map((set, index) =>
-                      index === 0 && serverSets[0]
-                        ? {
-                            ...set,
-                            id: serverSets[0].id,
-                            repetitions: serverSets[0].repetitions,
-                          }
-                        : set,
-                    ),
                   };
                 }),
               };

--- a/plans/2026-05-17_16-00_fix-default-set-phantom.md
+++ b/plans/2026-05-17_16-00_fix-default-set-phantom.md
@@ -1,0 +1,40 @@
+# Fix: phantom default set powodujący błędne statystyki (#63, #64)
+
+## Problem
+
+Backend w `addExerciseToWorkout` zawsze persystuje domyślną serię (`lastWeight × lastReps`) gdy użytkownik dodaje ćwiczenie do treningu. Jeśli użytkownik dodaje kolejne serie bez edytowania tej pierwszej, ukończony trening ma o jedną serię za dużo — stąd "4 serie zamiast 3" (#64). Ta sama domyślna seria zaburza `ExerciseUserStats.lastWeight/lastReps` jeśli trening z niekompletną domyślną serią ma nowszą datę (#63).
+
+## Root cause
+
+`workout.service.ts:177`: `addSetToWorkoutItem(item.id, defaultWeight, defaultReps, 1)` — persystuje serię bez potwierdzenia użytkownika.
+
+## Fix
+
+Przenieść odpowiedzialność za tworzenie pierwszej serii na użytkownika (jak dla kolejnych serii — `draftSet`):
+
+- Backend nie tworzy już domyślnej serii
+- Frontend nie tworzy optymistycznej serii
+- `WorkoutItemCard` auto-otwiera `draftSet` gdy `sets.length === 0`, pre-wypełniony `stats.lastWeight/lastReps`
+
+## Zmienione pliki (4)
+
+### 1. `backend/src/modules/workout/workout.service.ts`
+- Usuń blok `defaultWeight/defaultReps` (linie 166-177)
+- Usuń `addSetToWorkoutItem(...)` call
+
+### 2. `backend/src/modules/workout/workout.service.test.ts`
+- Aktualizuj test `addExerciseToWorkout`: usuń oczekiwanie `addSetToWorkoutItem`
+- Zmień nazwę testu
+
+### 3. `frontend/src/contexts/DataContext.tsx`
+- Usuń `tempSetId`, `exerciseStat`, `defaultWeight`, `defaultReps`
+- Zmień `sets: [{ ... }]` → `sets: []` w optimistic update
+- Usuń `clientTempSetId` z `syncPayload`
+- Uprość remap: tylko mapowanie ID item, bez sets
+
+### 4. `frontend/src/components/screens/WorkoutDetailScreen.tsx` (WorkoutItemCard)
+- Auto-inicjalizuj `draftSet` gdy `item.sets.length === 0 && canEdit`
+- Zaktualizuj "Dodaj serię" button — fallback do `stats` gdy brak `lastSet`
+
+## Szacunek zmian
+~50 linii (w granicach progu)


### PR DESCRIPTION
## Problem

Backend w `addExerciseToWorkout` zawsze persystował domyślną serię (`lastWeight × lastReps`) gdy użytkownik dodawał ćwiczenie do treningu. Jeśli użytkownik następnie dodawał kolejne serie bez edytowania tej pierwszej, ukończony trening miał o jedną serię za dużo — stąd dwa bugi:

- **#64** — "pokazuje 4 serie, a robiłem 3": domyślna seria (np. `150 kg × 1`) zostaje w DB obok 3 realnych serii
- **#63** — "Ostatnio: 150 kg × 1 zamiast 160 × 3": trening z niekompletną domyślną serią jako `lastPoint` w `ExerciseUserStats`

## Rozwiązanie

Backend nie tworzy już domyślnej serii. Pierwsza seria powstaje wyłącznie gdy użytkownik ją potwierdzi przez istniejący mechanizm `draftSet` w `WorkoutItemCard` — pre-wypełniony wartościami `ExerciseUserStats.lastWeight/lastReps`.

## Zmiany

- `backend/src/modules/workout/workout.service.ts` — usunięto blok `defaultWeight/defaultReps` i wywołanie `addSetToWorkoutItem` z `addExerciseToWorkout`
- `frontend/src/contexts/DataContext.tsx` — optimistic update tworzy item z `sets: []`; uproszczony remap (bez mapowania temp set ID)
- `frontend/src/components/screens/WorkoutDetailScreen.tsx` — `WorkoutItemCard` auto-otwiera `draftSet` gdy `sets.length === 0 && canEdit`, przycisk "+ Dodaj serię" używa `stats` jako fallback
- `backend/src/modules/workout/workout.service.test.ts` — zaktualizowany test
- `docs/modules/workout.md`, `CLAUDE.md` — zaktualizowana dokumentacja przepływu

## Test plan

- [ ] Dodaj ćwiczenie do nowego treningu → powinien pojawić się draft input (bez automatycznej serii w tle)
- [ ] Potwierdź draft → seria tworzona w DB, liczba serii = 1
- [ ] Dodaj 2 kolejne serie → łącznie 3, nie 4
- [ ] Ukończ trening → statystyki "Ostatnio" pokazują max ciężar z potwierdzonych serii
- [ ] Dodaj ćwiczenie do następnego treningu → draft pre-wypełniony poprawnymi wartościami z poprzedniego treningu

🤖 Generated with [Claude Code](https://claude.com/claude-code)