### PR TITLE
fix: prevent plan-not-found after re-seeding + exercise preview in plan cards

### DIFF
--- a/backend/prisma/seedWorkoutPlans.ts
+++ b/backend/prisma/seedWorkoutPlans.ts
@@ -4,9 +4,6 @@ import { BUILT_IN_USER_ID } from "../src/config/constants.js";
 export async function seedWorkoutPlans() {
   console.log("🌱 Seeding built-in workout plans...");
 
-  await prisma.workoutPlan.deleteMany({ where: { creatorUserId: null } });
-  console.log("✓ Cleared existing built-in plans");
-
   const globalExerciseName = "Prostowanie ramienia na wyciągu jednorącz";
   let globalExercise = await prisma.exercise.findFirst({
     where: { name: globalExerciseName, creatorUserId: null },
@@ -110,20 +107,51 @@ export async function seedWorkoutPlans() {
     );
   }
 
+  // Upsert: preserve existing plan IDs to avoid invalidating frontend caches
+  const existingPlans = await prisma.workoutPlan.findMany({
+    where: { creatorUserId: null },
+  });
+  const existingByName = new Map(existingPlans.map((p) => [p.name, p]));
+  const definitionNames = new Set(planDefinitions.map((p) => p.name));
+
+  // Delete plans no longer in definitions
+  for (const existing of existingPlans) {
+    if (!definitionNames.has(existing.name)) {
+      await prisma.workoutPlan.delete({ where: { id: existing.id } });
+      console.log(`✓ Removed obsolete built-in plan: ${existing.name}`);
+    }
+  }
+
   for (const plan of planDefinitions) {
-    await prisma.workoutPlan.create({
-      data: {
-        name: plan.name,
-        creatorUserId: null,
-        isPublic: true,
-        items: {
-          create: plan.exerciseNames.map((name, index) => ({
+    const existing = existingByName.get(plan.name);
+    if (existing) {
+      // Keep existing plan ID, just replace its items
+      await prisma.$transaction(async (tx) => {
+        await tx.workoutPlanItem.deleteMany({ where: { planId: existing.id } });
+        await tx.workoutPlanItem.createMany({
+          data: plan.exerciseNames.map((name, index) => ({
+            planId: existing.id,
             exerciseId: byName.get(name)!,
             orderInPlan: index,
           })),
+        });
+      });
+      console.log(`✓ Updated built-in plan: ${plan.name}`);
+    } else {
+      await prisma.workoutPlan.create({
+        data: {
+          name: plan.name,
+          creatorUserId: null,
+          isPublic: true,
+          items: {
+            create: plan.exerciseNames.map((name, index) => ({
+              exerciseId: byName.get(name)!,
+              orderInPlan: index,
+            })),
+          },
         },
-      },
-    });
-    console.log(`✓ Created built-in plan: ${plan.name}`);
+      });
+      console.log(`✓ Created built-in plan: ${plan.name}`);
+    }
   }
 }

--- a/frontend/src/components/screens/PlansScreen.tsx
+++ b/frontend/src/components/screens/PlansScreen.tsx
@@ -30,6 +30,7 @@ interface PlanCardProps {
 const PlanCard = memo(function PlanCard({ plan, isOwner, onEdit, onDuplicate }: PlanCardProps) {
   const muscles = getPlanMuscles(plan);
   const [duplicating, setDuplicating] = useState(false);
+  const [expanded, setExpanded] = useState(false);
   const { deletePlan } = useData();
 
   const handleDelete = async () => {
@@ -60,42 +61,93 @@ const PlanCard = memo(function PlanCard({ plan, isOwner, onEdit, onDuplicate }: 
         marginBottom: 12,
       }}
     >
-      <div className="flex items-start justify-between gap-2 mb-2">
-        <div className="flex-1 min-w-0">
-          <h3
-            className="font-barlow font-bold leading-tight truncate"
-            style={{ fontSize: 17, color: "var(--gg-text)" }}
-          >
-            {plan.name}
-          </h3>
-          <p className="text-[12px] mt-0.5" style={{ color: "var(--gg-text-muted)" }}>
-            {plan.items.length} {plan.items.length === 1 ? "ćwiczenie" : plan.items.length < 5 ? "ćwiczenia" : "ćwiczeń"}
-            {plan.isPublic && (
-              <span className="ml-2" style={{ color: "var(--gg-a1)" }}>• Publiczny</span>
-            )}
-          </p>
-        </div>
-      </div>
-
-      {muscles.length > 0 && (
-        <div className="flex flex-wrap gap-1 mb-3">
-          {muscles.map((m) => (
-            <span
-              key={m}
-              className="text-[11px] font-medium px-2 py-0.5 rounded-full"
-              style={{
-                background: "var(--gg-surface2)",
-                color: "var(--gg-text-sub)",
-                border: "1px solid var(--gg-border)",
-              }}
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        className="w-full text-left border-none bg-transparent cursor-pointer p-0"
+      >
+        <div className="flex items-start justify-between gap-2 mb-2">
+          <div className="flex-1 min-w-0">
+            <h3
+              className="font-barlow font-bold leading-tight truncate"
+              style={{ fontSize: 17, color: "var(--gg-text)" }}
             >
-              {muscleLabel(m)}
-            </span>
+              {plan.name}
+            </h3>
+            <p className="text-[12px] mt-0.5" style={{ color: "var(--gg-text-muted)" }}>
+              {plan.items.length} {plan.items.length === 1 ? "ćwiczenie" : plan.items.length < 5 ? "ćwiczenia" : "ćwiczeń"}
+              {plan.isPublic && (
+                <span className="ml-2" style={{ color: "var(--gg-a1)" }}>• Publiczny</span>
+              )}
+            </p>
+          </div>
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            style={{
+              color: "var(--gg-text-muted)",
+              flexShrink: 0,
+              marginTop: 3,
+              transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
+              transition: "transform 0.2s",
+            }}
+          >
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        </div>
+
+        {muscles.length > 0 && (
+          <div className="flex flex-wrap gap-1 mb-1">
+            {muscles.map((m) => (
+              <span
+                key={m}
+                className="text-[11px] font-medium px-2 py-0.5 rounded-full"
+                style={{
+                  background: "var(--gg-surface2)",
+                  color: "var(--gg-text-sub)",
+                  border: "1px solid var(--gg-border)",
+                }}
+              >
+                {muscleLabel(m)}
+              </span>
+            ))}
+          </div>
+        )}
+      </button>
+
+      {expanded && plan.items.length > 0 && (
+        <div
+          className="mt-2 mb-3"
+          style={{
+            borderTop: "1px solid var(--gg-border)",
+            paddingTop: 10,
+          }}
+        >
+          {plan.items.map((item, index) => (
+            <div
+              key={item.id}
+              className="flex items-center gap-2 py-1"
+            >
+              <span
+                className="text-[11px] font-bold w-5 text-right flex-shrink-0"
+                style={{ color: "var(--gg-text-muted)" }}
+              >
+                {index + 1}.
+              </span>
+              <span className="text-[13px]" style={{ color: "var(--gg-text-sub)" }}>
+                {item.exercise.name}
+              </span>
+            </div>
           ))}
         </div>
       )}
 
-      <div className="flex gap-2">
+      <div className="flex gap-2 mt-2">
         {isOwner && onEdit && (
           <button
             onClick={onEdit}

--- a/frontend/src/contexts/DataContext.tsx
+++ b/frontend/src/contexts/DataContext.tsx
@@ -641,7 +641,14 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
           body: JSON.stringify(data),
         });
 
-        if (!response.ok) throw new Error("Błąd tworzenia treningu");
+        if (!response.ok) {
+          if (response.status === 404) {
+            // Plan ID may be stale — refresh plans and surface a clear message
+            fetchAllFromServer().catch(() => {});
+            throw new Error("Plan nie istnieje — plany zostały odświeżone, spróbuj ponownie.");
+          }
+          throw new Error("Błąd tworzenia treningu");
+        }
 
         const result = await response.json();
         const newWorkout = result.data;
@@ -692,7 +699,7 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
         return tempWorkout;
       }
     },
-    [isOfflineError, queueSyncOperation, user?.id],
+    [isOfflineError, queueSyncOperation, user?.id, fetchAllFromServer],
   );
 
   const updateWorkout = useCallback(
@@ -1911,6 +1918,10 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
     });
 
     if (!response.ok) {
+      if (response.status === 404) {
+        fetchAllFromServer().catch(() => {});
+        throw new Error("Plan nie istnieje — plany zostały odświeżone, spróbuj ponownie.");
+      }
       const err = await response.json().catch(() => ({}));
       throw new Error(err?.message || "Błąd duplikacji planu");
     }
@@ -1922,7 +1933,7 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
     await localStore.put("plans", newPlan);
 
     return newPlan;
-  }, []);
+  }, [fetchAllFromServer]);
 
   const skipPlanExercise = useCallback(async (workoutId: string, exerciseId: string) => {
     const realWorkoutId = getRealId(workoutId);


### PR DESCRIPTION
## Summary

- **Root cause fix** — `seedWorkoutPlans.ts` used `deleteMany + create` which generated new UUIDs every run, invalidating all frontend IndexedDB caches. Replaced with upsert-by-name: existing plans keep their IDs, obsolete plans are deleted.
- **Defensive frontend** — `createWorkout` and `duplicatePlan` now handle 404 gracefully: silently refresh plans from server and surface a clear "spróbuj ponownie" message instead of a generic error.
- **New feature** — clicking a plan card expands an ordered list of exercises; chevron animates on toggle.

## Test plan

- [ ] Run `npm run seed:plans` twice — second run should log `✓ Updated` not `✓ Created`, plan IDs in DB stay the same
- [ ] Open Plans screen → click any plan card → exercise list expands/collapses with chevron animation
- [ ] Duplicate a built-in plan → should work and appear in "Moje" tab
- [ ] Create a workout with a plan selected → no "Plan not found" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)