### PR TITLE
fix: prevent duplicate set numbers in offline/error scenarios

### DIFF
--- a/backend/src/modules/workout/workout.service.ts
+++ b/backend/src/modules/workout/workout.service.ts
@@ -236,11 +236,8 @@ export const addSetToWorkoutItem = async (
     throw new Error("Brak uprawnień");
   }
 
-  let setNumber = data.setNumber;
-  if (!setNumber) {
-    const maxSetNumber = await workoutRepo.getMaxSetNumber(itemId);
-    setNumber = maxSetNumber + 1;
-  }
+  const maxSetNumber = await workoutRepo.getMaxSetNumber(itemId);
+  const setNumber = maxSetNumber + 1;
 
   const createdSet = await workoutRepo.addSetToWorkoutItem(
     itemId,

--- a/frontend/src/components/screens/WorkoutDetailScreen.tsx
+++ b/frontend/src/components/screens/WorkoutDetailScreen.tsx
@@ -1247,11 +1247,11 @@ const WorkoutItemCard = memo(
                 )}
                 {draftSet && canEdit && (
                   <DraftSetRow
-                    setNumber={item.sets.length + 1}
+                    setNumber={Math.max(0, ...item.sets.map((s) => s.setNumber)) + 1}
                     defaultWeight={draftSet.weight}
                     defaultReps={draftSet.reps}
                     onConfirm={(w, r) => {
-                      onAddSet(item.id, { weight: w, repetitions: r, setNumber: item.sets.length + 1 });
+                      onAddSet(item.id, { weight: w, repetitions: r, setNumber: Math.max(0, ...item.sets.map((s) => s.setNumber)) + 1 });
                       setDraftSet(null);
                     }}
                     onCancel={() => setDraftSet(null)}


### PR DESCRIPTION
## Summary

- **Server**: always computes `setNumber = maxSetNumber + 1`, ignoring client-supplied value — eliminates all server-side duplicate set numbers regardless of client behavior
- **Client**: draft set display uses `max(setNumbers) + 1` instead of `length + 1` — correct suggested number even after deleting a set mid-session

## Root causes fixed

**Root cause 1 — client** (`WorkoutDetailScreen.tsx`): `item.sets.length + 1` gave wrong setNumber when sets had gaps (e.g. delete set 2 from [1,2,3] → length=2 → new set number=3, conflicting with existing 3).

**Root cause 2 — server** (`workout.service.ts`): server trusted client's `setNumber` unconditionally. Client always sends a number, so server never auto-computed it. On rollback+retry or delete+add offline, the same number was sent twice and the server created a duplicate.

## Test plan

- [ ] Add sets normally online — numbers are sequential
- [ ] Delete a set, add a new one — new set gets `max+1`, no conflict
- [ ] Go offline, add sets, come back online — sync assigns correct sequential numbers
- [ ] Delete a set offline, add a new one offline, sync — no duplicate numbers after sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)