### PR TITLE
fix: admin can edit/delete any global exercise + improve isGlobal toggle UI

### DIFF
--- a/backend/src/modules/exercise/exercise.controller.ts
+++ b/backend/src/modules/exercise/exercise.controller.ts
@@ -99,14 +99,12 @@ export class ExerciseController {
         data: exercise,
       });
     } catch (error) {
-      const statusCode =
-        error instanceof Error && error.message === "Exercise not found"
-          ? 404
-          : 400;
+      const msg = error instanceof Error ? error.message : "";
+      const statusCode = msg === "Exercise not found" ? 404 : msg.startsWith("Unauthorized") ? 403 : 400;
 
       res.status(statusCode).json({
         success: false,
-        error: error instanceof Error ? error.message : "Bad request",
+        error: msg || "Bad request",
       });
     }
   }
@@ -118,14 +116,12 @@ export class ExerciseController {
 
       res.status(204).send();
     } catch (error) {
-      const statusCode =
-        error instanceof Error && error.message === "Exercise not found"
-          ? 404
-          : 500;
+      const msg = error instanceof Error ? error.message : "";
+      const statusCode = msg === "Exercise not found" ? 404 : msg.startsWith("Unauthorized") ? 403 : 500;
 
       res.status(statusCode).json({
         success: false,
-        error: error instanceof Error ? error.message : "Internal server error",
+        error: msg || "Internal server error",
       });
     }
   }

--- a/backend/src/modules/exercise/exercise.controller.ts
+++ b/backend/src/modules/exercise/exercise.controller.ts
@@ -90,7 +90,8 @@ export class ExerciseController {
       const exercise = await this.service.updateExercise(
         id,
         req.body,
-        req.userId!
+        req.userId!,
+        req.userIsAdmin
       );
 
       res.json({
@@ -113,7 +114,7 @@ export class ExerciseController {
   async delete(req: AuthRequest, res: Response) {
     try {
       const { id } = req.params as { id: string };
-      await this.service.deleteExercise(id, req.userId!);
+      await this.service.deleteExercise(id, req.userId!, req.userIsAdmin);
 
       res.status(204).send();
     } catch (error) {

--- a/backend/src/modules/exercise/exercise.service.ts
+++ b/backend/src/modules/exercise/exercise.service.ts
@@ -30,21 +30,27 @@ export class ExerciseService {
     return this.repository.create(data);
   }
 
-  async updateExercise(id: string, data: UpdateExerciseDto, userId: string) {
+  async updateExercise(id: string, data: UpdateExerciseDto, userId: string, isAdmin = false) {
     const exercise = await this.getExerciseById(id);
+    const isGlobal = exercise.creatorUserId === null || exercise.creatorUserId === "1";
 
-    if (exercise.creatorUserId !== userId) {
-      throw new Error("Unauthorized: You can only edit your own exercises");
+    if (!isAdmin || !isGlobal) {
+      if (exercise.creatorUserId !== userId) {
+        throw new Error("Unauthorized: You can only edit your own exercises");
+      }
     }
 
     return this.repository.update(id, data);
   }
 
-  async deleteExercise(id: string, userId: string) {
+  async deleteExercise(id: string, userId: string, isAdmin = false) {
     const exercise = await this.getExerciseById(id);
+    const isGlobal = exercise.creatorUserId === null || exercise.creatorUserId === "1";
 
-    if (exercise.creatorUserId !== userId) {
-      throw new Error("Unauthorized: You can only delete your own exercises");
+    if (!isAdmin || !isGlobal) {
+      if (exercise.creatorUserId !== userId) {
+        throw new Error("Unauthorized: You can only delete your own exercises");
+      }
     }
 
     return this.repository.delete(id);

--- a/frontend/src/components/exercises/ExerciseList.tsx
+++ b/frontend/src/components/exercises/ExerciseList.tsx
@@ -214,7 +214,7 @@ function ExerciseItem({ exercise, mode, stats, onSelect, onEdit, onDelete, perfo
   const { user } = useAuth();
   const creatorId = exercise.creator?.id;
   const isGlobal = creatorId == null || creatorId === "1";
-  const canEdit = user && (String(creatorId) === String(user.id) || (user.isAdmin && isGlobal));
+  const canEdit = user && ((creatorId != null && creatorId === user.id) || (user.isAdmin && isGlobal));
   const isPerformed = performedHighlight && !!stats;
 
   return (

--- a/frontend/src/components/exercises/ExerciseList.tsx
+++ b/frontend/src/components/exercises/ExerciseList.tsx
@@ -213,7 +213,8 @@ interface ExerciseItemProps {
 function ExerciseItem({ exercise, mode, stats, onSelect, onEdit, onDelete, performedHighlight }: ExerciseItemProps) {
   const { user } = useAuth();
   const creatorId = exercise.creator?.id;
-  const canEdit = user && creatorId != null && String(creatorId) === String(user.id);
+  const isGlobal = creatorId == null || creatorId === "1";
+  const canEdit = user && (String(creatorId) === String(user.id) || (user.isAdmin && isGlobal));
   const isPerformed = performedHighlight && !!stats;
 
   return (

--- a/frontend/src/components/screens/AddExerciseScreen.tsx
+++ b/frontend/src/components/screens/AddExerciseScreen.tsx
@@ -179,16 +179,36 @@ export const AddExerciseScreen = memo(function AddExerciseScreen({
 
         {isAdmin && (
           <div
-            className="flex items-center justify-between rounded-[14px]"
-            style={{ padding: "14px 16px", background: "var(--gg-surface)", border: "1.5px solid var(--gg-border)" }}
+            className="flex items-center justify-between rounded-[14px] transition-all duration-200"
+            style={{
+              padding: "14px 16px",
+              background: isGlobal ? "color-mix(in srgb, var(--gg-a2) 6%, var(--gg-surface))" : "var(--gg-surface)",
+              border: `1.5px solid ${isGlobal ? "var(--gg-a2)" : "var(--gg-border)"}`,
+            }}
           >
-            <div>
-              <p className="text-[14px] font-semibold" style={{ color: "var(--gg-text)" }}>
-                Dodaj dla wszystkich
-              </p>
-              <p className="text-[12px] mt-0.5" style={{ color: "var(--gg-text-muted)" }}>
-                Ćwiczenie będzie widoczne globalnie
-              </p>
+            <div className="flex items-center gap-2.5">
+              <div
+                className="flex items-center justify-center flex-shrink-0 rounded-[10px]"
+                style={{
+                  width: 34,
+                  height: 34,
+                  background: isGlobal ? "color-mix(in srgb, var(--gg-a2) 15%, transparent)" : "var(--gg-surface2)",
+                }}
+              >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke={isGlobal ? "var(--gg-a2)" : "var(--gg-text-muted)"} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx="12" cy="12" r="10"/>
+                  <line x1="2" y1="12" x2="22" y2="12"/>
+                  <path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/>
+                </svg>
+              </div>
+              <div>
+                <p className="text-[14px] font-semibold" style={{ color: "var(--gg-text)" }}>
+                  Globalne ćwiczenie
+                </p>
+                <p className="text-[12px] mt-0.5" style={{ color: "var(--gg-text-muted)" }}>
+                  Widoczne dla wszystkich użytkowników
+                </p>
+              </div>
             </div>
             <button
               type="button"
@@ -199,21 +219,22 @@ export const AddExerciseScreen = memo(function AddExerciseScreen({
               className="relative flex-shrink-0 rounded-full transition-colors duration-200"
               style={{
                 width: 44,
-                height: 24,
-                background: isGlobal ? "var(--gg-a2)" : "var(--gg-border)",
-                border: "none",
+                height: 26,
+                background: isGlobal ? "var(--gg-a2)" : "var(--gg-surface2)",
+                border: `1.5px solid ${isGlobal ? "var(--gg-a2)" : "var(--gg-border)"}`,
                 cursor: "pointer",
               }}
             >
               <span
-                className="absolute top-[2px] rounded-full transition-transform duration-200"
+                className="absolute rounded-full transition-transform duration-200"
                 style={{
-                  width: 20,
-                  height: 20,
+                  width: 18,
+                  height: 18,
                   background: "white",
+                  top: 2,
                   left: 2,
-                  transform: isGlobal ? "translateX(20px)" : "translateX(0)",
-                  boxShadow: "0 1px 4px rgba(0,0,0,0.18)",
+                  transform: isGlobal ? "translateX(18px)" : "translateX(0)",
+                  boxShadow: "0 1px 4px rgba(0,0,0,0.22)",
                 }}
               />
             </button>


### PR DESCRIPTION
## Summary

- **Admin permissions**: admin może teraz edytować i usuwać każde globalne ćwiczenie (`creatorUserId = null` lub `"1"`), nie tylko te, które sam stworzył
- **Backend**: `updateExercise` / `deleteExercise` w serwisie przyjmują `isAdmin` — bypass sprawdzenia właściciela gdy admin + ćwiczenie globalne
- **Frontend list**: `canEdit` w `ExerciseList` uwzględnia `user.isAdmin && isGlobal` — przyciski edycji/usuwania widoczne dla admina przy wszystkich globalnych ćwiczeniach
- **Toggle UI**: przycisk `isGlobal` w `AddExerciseScreen` — ikona globusa, kolorowy border kontenera gdy aktywny, lepszy kontrast stanu inactive

## Test plan

- [ ] Admin widzi przyciski edycji/usuwania przy ćwiczeniach globalnych (`creatorUserId = null` i `"1"`)
- [ ] Admin NIE widzi przycisków przy ćwiczeniach innych użytkowników (nie-globalnych)
- [ ] Zwykły user widzi przyciski tylko przy swoich ćwiczeniach (bez zmian)
- [ ] Backend: `PUT /api/exercises/:id` zwraca 200 dla admina na globalnym, 400 na cudzym
- [ ] Toggle isGlobal w formularzu — poprawna animacja, kolorowy border przy włączeniu

🤖 Generated with [Claude Code](https://claude.com/claude-code)