### PR TITLE
fix(sync): stop duplicate workouts and data loss in offline-first flow

### DIFF
--- a/backend/src/modules/workout/workout.repository.ts
+++ b/backend/src/modules/workout/workout.repository.ts
@@ -29,6 +29,71 @@ export const createWorkout = (data: Prisma.WorkoutCreateInput) => {
   });
 };
 
+const workoutInclude = {
+  items: {
+    include: {
+      exercise: {
+        include: {
+          photos: true,
+        },
+      },
+      sets: {
+        orderBy: { setNumber: "asc" as const },
+      },
+    },
+    orderBy: { orderInWorkout: "asc" as const },
+  },
+} satisfies Prisma.WorkoutInclude;
+
+/**
+ * Tworzy trening w sposób odporny na wyścig (rapid double/triple-tap, równoległe
+ * żądania offline-sync). Blokuje wiersz użytkownika (SELECT ... FOR UPDATE), więc
+ * równoległe żądania tego samego usera są serializowane: pierwszy tworzy DRAFT i
+ * ustawia activeWorkoutId, kolejne widzą już aktywny trening i go zwracają zamiast
+ * tworzyć duplikat.
+ *
+ * @returns workout oraz flagę `reused` (true => zwrócono istniejący aktywny trening)
+ */
+export const createWorkoutWithActiveGuard = async (
+  userId: string,
+  data: Prisma.WorkoutCreateInput,
+): Promise<{ workout: WorkoutWithItems; reused: boolean }> => {
+  return prisma.$transaction(async (tx) => {
+    // Lock wiersza użytkownika — serializuje równoległe tworzenie treningu.
+    await tx.$queryRaw`SELECT id FROM "users" WHERE id = ${userId} FOR UPDATE`;
+
+    const user = await tx.user.findUnique({
+      where: { id: userId },
+      select: { activeWorkoutId: true },
+    });
+
+    if (user?.activeWorkoutId) {
+      const active = await tx.workout.findUnique({
+        where: { id: user.activeWorkoutId },
+        include: workoutInclude,
+      });
+      // Reużyj tylko jeśli aktywny trening nadal istnieje i jest w trakcie (DRAFT).
+      if (active && active.status === "DRAFT") {
+        return { workout: active, reused: true };
+      }
+    }
+
+    const workout = await tx.workout.create({
+      data,
+      include: workoutInclude,
+    });
+
+    await tx.user.update({
+      where: { id: userId },
+      data: { activeWorkoutId: workout.id },
+    });
+
+    return { workout, reused: false };
+  });
+};
+
+type WorkoutWithItems = Prisma.WorkoutGetPayload<{ include: typeof workoutInclude }>;
+
 export const findWorkoutById = (id: string) => {
   return prisma.workout.findUnique({
     where: { id },

--- a/backend/src/modules/workout/workout.repository.ts
+++ b/backend/src/modules/workout/workout.repository.ts
@@ -620,9 +620,28 @@ export const getActiveWorkout = (userId: string) => {
   });
 };
 
+// Lekkie sprawdzenie statusu treningu — bez ciągnięcia items/sets/photos.
+// Używane na często wołanym endpoincie /workouts/active.
+export const findWorkoutStatus = (id: string) => {
+  return prisma.workout.findUnique({
+    where: { id },
+    select: { status: true },
+  });
+};
+
 export const clearActiveWorkout = (userId: string) => {
   return prisma.user.update({
     where: { id: userId },
+    data: { activeWorkoutId: null },
+  });
+};
+
+// Czyści wskaźnik aktywnego treningu TYLKO jeśli nadal wskazuje na podany
+// (nieaktualny) id. Zapobiega wyścigowi: równoległy createWorkout mógł właśnie
+// ustawić nowy aktywny trening, którego nie wolno nam wyzerować.
+export const clearActiveWorkoutIfMatches = (userId: string, workoutId: string) => {
+  return prisma.user.updateMany({
+    where: { id: userId, activeWorkoutId: workoutId },
     data: { activeWorkoutId: null },
   });
 };

--- a/backend/src/modules/workout/workout.service.test.ts
+++ b/backend/src/modules/workout/workout.service.test.ts
@@ -6,6 +6,7 @@ vi.mock("./workout.repository.js", () => ({
   getActiveWorkout: vi.fn(),
   findWorkoutById: vi.fn(),
   createWorkout: vi.fn(),
+  createWorkoutWithActiveGuard: vi.fn(),
   setActiveWorkout: vi.fn(),
   findWorkoutsByUser: vi.fn(),
   updateWorkout: vi.fn(),
@@ -41,39 +42,42 @@ describe("workout.service", () => {
     vi.mocked(workoutRepo.getLastWorkoutNote).mockResolvedValue(null);
   });
 
-  it("createWorkout: returns active workout when one already exists", async () => {
-    vi.mocked(workoutRepo.getActiveWorkout).mockResolvedValue({
-      activeWorkoutId: "w1",
-    } as any);
-    vi.mocked(workoutRepo.findWorkoutById).mockResolvedValue({
-      id: "w1",
-      userId: "u1",
-    } as any);
+  it("createWorkout: reuses active workout returned by the race-safe guard", async () => {
+    vi.mocked(workoutRepo.createWorkoutWithActiveGuard).mockResolvedValue({
+      workout: { id: "w1", userId: "u1", status: "DRAFT" } as any,
+      reused: true,
+    });
 
     const result = await workoutService.createWorkout("u1", {});
 
-    expect(result).toEqual({ id: "w1", userId: "u1" });
+    expect(result).toEqual({ id: "w1", userId: "u1", status: "DRAFT" });
+    expect(workoutRepo.createWorkoutWithActiveGuard).toHaveBeenCalledTimes(1);
+    // Legacy non-atomic path must not be used anymore.
     expect(workoutRepo.createWorkout).not.toHaveBeenCalled();
     expect(workoutRepo.setActiveWorkout).not.toHaveBeenCalled();
   });
 
-  it("createWorkout: creates new workout and sets activeWorkoutId when none exists", async () => {
-    vi.mocked(workoutRepo.getActiveWorkout).mockResolvedValue({
-      activeWorkoutId: null,
-    } as any);
-    vi.mocked(workoutRepo.createWorkout).mockResolvedValue({
-      id: "w-new",
-      userId: "u1",
-    } as any);
+  it("createWorkout: creates a new workout via the race-safe guard when none is active", async () => {
+    vi.mocked(workoutRepo.createWorkoutWithActiveGuard).mockResolvedValue({
+      workout: { id: "w-new", userId: "u1", status: "DRAFT" } as any,
+      reused: false,
+    });
 
     const result = await workoutService.createWorkout("u1", {
       workoutName: "Push Day",
       gymName: "Gym A",
     });
 
-    expect(workoutRepo.createWorkout).toHaveBeenCalled();
-    expect(workoutRepo.setActiveWorkout).toHaveBeenCalledWith("u1", "w-new");
-    expect(result).toEqual({ id: "w-new", userId: "u1" });
+    expect(workoutRepo.createWorkoutWithActiveGuard).toHaveBeenCalledWith(
+      "u1",
+      expect.objectContaining({
+        workoutName: "Push Day",
+        gymName: "Gym A",
+        user: { connect: { id: "u1" } },
+      }),
+    );
+    expect(workoutRepo.createWorkout).not.toHaveBeenCalled();
+    expect(result).toEqual({ id: "w-new", userId: "u1", status: "DRAFT" });
   });
 
   it("getWorkoutById: throws when workout belongs to another user", async () => {
@@ -503,6 +507,48 @@ describe("workout.service", () => {
     });
   });
 
+  it("getActiveWorkoutId: returns id when active workout exists and is DRAFT", async () => {
+    vi.mocked(workoutRepo.getActiveWorkout).mockResolvedValue({
+      activeWorkoutId: "w1",
+    } as any);
+    vi.mocked(workoutRepo.findWorkoutById).mockResolvedValue({
+      id: "w1",
+      status: "DRAFT",
+    } as any);
+
+    const result = await workoutService.getActiveWorkoutId("u1");
+
+    expect(result).toBe("w1");
+    expect(workoutRepo.clearActiveWorkout).not.toHaveBeenCalled();
+  });
+
+  it("getActiveWorkoutId: self-heals stale pointer to a COMPLETED workout", async () => {
+    vi.mocked(workoutRepo.getActiveWorkout).mockResolvedValue({
+      activeWorkoutId: "w1",
+    } as any);
+    vi.mocked(workoutRepo.findWorkoutById).mockResolvedValue({
+      id: "w1",
+      status: "COMPLETED",
+    } as any);
+
+    const result = await workoutService.getActiveWorkoutId("u1");
+
+    expect(result).toBeNull();
+    expect(workoutRepo.clearActiveWorkout).toHaveBeenCalledWith("u1");
+  });
+
+  it("getActiveWorkoutId: self-heals pointer to a missing workout", async () => {
+    vi.mocked(workoutRepo.getActiveWorkout).mockResolvedValue({
+      activeWorkoutId: "w-gone",
+    } as any);
+    vi.mocked(workoutRepo.findWorkoutById).mockResolvedValue(null as any);
+
+    const result = await workoutService.getActiveWorkoutId("u1");
+
+    expect(result).toBeNull();
+    expect(workoutRepo.clearActiveWorkout).toHaveBeenCalledWith("u1");
+  });
+
   it("getStatsOverview: returns aggregated stats from repository", async () => {
     vi.mocked(workoutRepo.getStatsOverview).mockResolvedValue({
       workoutsLastMonth: 3,
@@ -557,6 +603,136 @@ describe("workout.service", () => {
         },
       ],
     });
+  });
+
+  it("getWorkoutById: throws not-found when workout is missing", async () => {
+    vi.mocked(workoutRepo.findWorkoutById).mockResolvedValue(null as any);
+
+    await expect(workoutService.getWorkoutById("missing", "u1")).rejects.toThrow(
+      /nie znaleziony/,
+    );
+  });
+
+  it("addExerciseToWorkout: rebuilds stats when adding to a COMPLETED workout", async () => {
+    vi.mocked(workoutRepo.findWorkoutById).mockResolvedValue({
+      id: "w1",
+      userId: "u1",
+      status: "COMPLETED",
+    } as any);
+    vi.mocked(workoutRepo.getMaxOrderInWorkout).mockResolvedValue(0);
+    vi.mocked(workoutRepo.addExerciseToWorkoutWithPendingNote).mockResolvedValue({
+      id: "item-1",
+    } as any);
+    vi.mocked(workoutRepo.findWorkoutItemById).mockResolvedValue({
+      id: "item-1",
+      workoutId: "w1",
+    } as any);
+    vi.mocked(workoutRepo.getExerciseProgression).mockResolvedValue([]);
+
+    await workoutService.addExerciseToWorkout("w1", "u1", { exerciseId: "e1" });
+
+    expect(workoutRepo.getExerciseProgression).toHaveBeenCalledWith("u1", "e1");
+    expect(workoutRepo.deleteExerciseStats).toHaveBeenCalledWith("u1", "e1");
+  });
+
+  it("deleteWorkoutItem: rejects when caller is not the owner", async () => {
+    vi.mocked(workoutRepo.findWorkoutItemById).mockResolvedValue({
+      id: "item-1",
+      workoutId: "w1",
+      exerciseId: "e1",
+    } as any);
+    vi.mocked(workoutRepo.findWorkoutById).mockResolvedValue({
+      id: "w1",
+      userId: "other",
+      status: "DRAFT",
+    } as any);
+
+    await expect(
+      workoutService.deleteWorkoutItem("item-1", "u1"),
+    ).rejects.toThrow(/uprawnień/);
+    expect(workoutRepo.deleteWorkoutItem).not.toHaveBeenCalled();
+  });
+
+  it("deleteWorkoutItem: deletes and rebuilds stats for a COMPLETED workout", async () => {
+    vi.mocked(workoutRepo.findWorkoutItemById).mockResolvedValue({
+      id: "item-1",
+      workoutId: "w1",
+      exerciseId: "e1",
+    } as any);
+    vi.mocked(workoutRepo.findWorkoutById).mockResolvedValue({
+      id: "w1",
+      userId: "u1",
+      status: "COMPLETED",
+    } as any);
+    vi.mocked(workoutRepo.deleteWorkoutItem).mockResolvedValue({ id: "item-1" } as any);
+    vi.mocked(workoutRepo.getExerciseProgression).mockResolvedValue([]);
+
+    await workoutService.deleteWorkoutItem("item-1", "u1");
+
+    expect(workoutRepo.deleteWorkoutItem).toHaveBeenCalledWith("item-1");
+    expect(workoutRepo.deleteExerciseStats).toHaveBeenCalledWith("u1", "e1");
+  });
+
+  it("addSetToWorkoutItem: rejects when caller is not the owner", async () => {
+    vi.mocked(workoutRepo.findWorkoutItemById).mockResolvedValue({
+      id: "item-1",
+      workoutId: "w1",
+    } as any);
+    vi.mocked(workoutRepo.findWorkoutById).mockResolvedValue({
+      id: "w1",
+      userId: "other",
+    } as any);
+
+    await expect(
+      workoutService.addSetToWorkoutItem("item-1", "u1", { weight: 10, repetitions: 5 }),
+    ).rejects.toThrow(/uprawnień/);
+    expect(workoutRepo.addSetToWorkoutItem).not.toHaveBeenCalled();
+  });
+
+  it("deleteWorkoutSet: deletes the set and rebuilds stats for a COMPLETED workout", async () => {
+    vi.mocked(workoutRepo.findWorkoutSetById).mockResolvedValue({
+      id: "set-1",
+      itemId: "item-1",
+    } as any);
+    vi.mocked(workoutRepo.findWorkoutItemById).mockResolvedValue({
+      id: "item-1",
+      workoutId: "w1",
+      exerciseId: "e1",
+    } as any);
+    vi.mocked(workoutRepo.findWorkoutById).mockResolvedValue({
+      id: "w1",
+      userId: "u1",
+      status: "COMPLETED",
+    } as any);
+    vi.mocked(workoutRepo.deleteWorkoutSet).mockResolvedValue({ id: "set-1" } as any);
+    vi.mocked(workoutRepo.getExerciseProgression).mockResolvedValue([]);
+
+    await workoutService.deleteWorkoutSet("set-1", "u1");
+
+    expect(workoutRepo.deleteWorkoutSet).toHaveBeenCalledWith("set-1");
+    expect(workoutRepo.deleteExerciseStats).toHaveBeenCalledWith("u1", "e1");
+  });
+
+  it("deleteWorkoutSet: throws when the set does not exist", async () => {
+    vi.mocked(workoutRepo.findWorkoutSetById).mockResolvedValue(null as any);
+
+    await expect(workoutService.deleteWorkoutSet("gone", "u1")).rejects.toThrow(
+      /Nie znaleziono serii/,
+    );
+  });
+
+  it("clearActiveWorkout: delegates to the repository", async () => {
+    await workoutService.clearActiveWorkout("u1");
+    expect(workoutRepo.clearActiveWorkout).toHaveBeenCalledWith("u1");
+  });
+
+  it("getAllUserStats / getExerciseStatsForUser: pass through to the repository", async () => {
+    vi.mocked(workoutRepo.getAllUserStats).mockResolvedValue([{ id: "s1" }] as any);
+    vi.mocked(workoutRepo.getExerciseStats).mockResolvedValue({ id: "s1" } as any);
+
+    expect(await workoutService.getAllUserStats("u1")).toEqual([{ id: "s1" }]);
+    expect(await workoutService.getExerciseStatsForUser("u1", "e1")).toEqual({ id: "s1" });
+    expect(workoutRepo.getExerciseStats).toHaveBeenCalledWith("u1", "e1");
   });
 
   describe("getNextFromPlan", () => {

--- a/backend/src/modules/workout/workout.service.test.ts
+++ b/backend/src/modules/workout/workout.service.test.ts
@@ -34,6 +34,8 @@ vi.mock("./workout.repository.js", () => ({
   clearPendingExerciseNote: vi.fn(),
   findWorkoutWithPlan: vi.fn(),
   setSkippedPlanExerciseIds: vi.fn(),
+  findWorkoutStatus: vi.fn(),
+  clearActiveWorkoutIfMatches: vi.fn(),
 }));
 
 describe("workout.service", () => {
@@ -511,42 +513,42 @@ describe("workout.service", () => {
     vi.mocked(workoutRepo.getActiveWorkout).mockResolvedValue({
       activeWorkoutId: "w1",
     } as any);
-    vi.mocked(workoutRepo.findWorkoutById).mockResolvedValue({
-      id: "w1",
+    vi.mocked(workoutRepo.findWorkoutStatus).mockResolvedValue({
       status: "DRAFT",
     } as any);
 
     const result = await workoutService.getActiveWorkoutId("u1");
 
     expect(result).toBe("w1");
-    expect(workoutRepo.clearActiveWorkout).not.toHaveBeenCalled();
+    expect(workoutRepo.clearActiveWorkoutIfMatches).not.toHaveBeenCalled();
   });
 
-  it("getActiveWorkoutId: self-heals stale pointer to a COMPLETED workout", async () => {
+  it("getActiveWorkoutId: self-heals stale pointer to a COMPLETED workout (conditional clear)", async () => {
     vi.mocked(workoutRepo.getActiveWorkout).mockResolvedValue({
       activeWorkoutId: "w1",
     } as any);
-    vi.mocked(workoutRepo.findWorkoutById).mockResolvedValue({
-      id: "w1",
+    vi.mocked(workoutRepo.findWorkoutStatus).mockResolvedValue({
       status: "COMPLETED",
     } as any);
 
     const result = await workoutService.getActiveWorkoutId("u1");
 
     expect(result).toBeNull();
-    expect(workoutRepo.clearActiveWorkout).toHaveBeenCalledWith("u1");
+    // Conditional clear keyed on the stale id, so a concurrent createWorkout
+    // that activated a new workout is not clobbered.
+    expect(workoutRepo.clearActiveWorkoutIfMatches).toHaveBeenCalledWith("u1", "w1");
   });
 
   it("getActiveWorkoutId: self-heals pointer to a missing workout", async () => {
     vi.mocked(workoutRepo.getActiveWorkout).mockResolvedValue({
       activeWorkoutId: "w-gone",
     } as any);
-    vi.mocked(workoutRepo.findWorkoutById).mockResolvedValue(null as any);
+    vi.mocked(workoutRepo.findWorkoutStatus).mockResolvedValue(null as any);
 
     const result = await workoutService.getActiveWorkoutId("u1");
 
     expect(result).toBeNull();
-    expect(workoutRepo.clearActiveWorkout).toHaveBeenCalledWith("u1");
+    expect(workoutRepo.clearActiveWorkoutIfMatches).toHaveBeenCalledWith("u1", "w-gone");
   });
 
   it("getStatsOverview: returns aggregated stats from repository", async () => {

--- a/backend/src/modules/workout/workout.service.ts
+++ b/backend/src/modules/workout/workout.service.ts
@@ -20,16 +20,6 @@ import {
 type StatsProgressMetric = "maxSetWeight" | "volume";
 
 export const createWorkout = async (userId: string, data: CreateWorkoutDto) => {
-  const existingActive = await workoutRepo.getActiveWorkout(userId);
-  if (existingActive?.activeWorkoutId) {
-    const activeWorkout = await workoutRepo.findWorkoutById(
-      existingActive.activeWorkoutId
-    );
-    if (activeWorkout) {
-      return activeWorkout;
-    }
-  }
-
   if (data.workoutPlanId) {
     // Throws NotFoundError gdy plan nie istnieje lub nie jest widoczny dla usera.
     // Zapobiega podpinaniu treningu pod prywatny plan innego użytkownika.
@@ -47,9 +37,13 @@ export const createWorkout = async (userId: string, data: CreateWorkoutDto) => {
       plan: { connect: { id: data.workoutPlanId } },
     }),
   };
-  const workout = await workoutRepo.createWorkout(workoutData);
 
-  await workoutRepo.setActiveWorkout(userId, workout.id);
+  // Odporne na wyścig: lock wiersza usera serializuje równoległe żądania, więc
+  // potrójne tapnięcie / równoległy sync nie tworzy zduplikowanych treningów.
+  const { workout } = await workoutRepo.createWorkoutWithActiveGuard(
+    userId,
+    workoutData,
+  );
 
   return workout;
 };
@@ -401,7 +395,19 @@ const syncPendingNoteForExercise = async (
 
 export const getActiveWorkoutId = async (userId: string) => {
   const result = await workoutRepo.getActiveWorkout(userId);
-  return result?.activeWorkoutId || null;
+  const activeId = result?.activeWorkoutId;
+  if (!activeId) return null;
+
+  // Self-heal: jeśli wskaźnik aktywnego treningu pokazuje na trening, który już
+  // nie istnieje albo jest COMPLETED, wyczyść go. Bez tego zakończony (lub
+  // usunięty) trening wracałby jako "w trakcie" po ponownym wejściu do aplikacji.
+  const workout = await workoutRepo.findWorkoutById(activeId);
+  if (!workout || workout.status === "COMPLETED") {
+    await workoutRepo.clearActiveWorkout(userId);
+    return null;
+  }
+
+  return activeId;
 };
 
 export const clearActiveWorkout = async (userId: string) => {

--- a/backend/src/modules/workout/workout.service.ts
+++ b/backend/src/modules/workout/workout.service.ts
@@ -401,9 +401,11 @@ export const getActiveWorkoutId = async (userId: string) => {
   // Self-heal: jeśli wskaźnik aktywnego treningu pokazuje na trening, który już
   // nie istnieje albo jest COMPLETED, wyczyść go. Bez tego zakończony (lub
   // usunięty) trening wracałby jako "w trakcie" po ponownym wejściu do aplikacji.
-  const workout = await workoutRepo.findWorkoutById(activeId);
+  const workout = await workoutRepo.findWorkoutStatus(activeId);
   if (!workout || workout.status === "COMPLETED") {
-    await workoutRepo.clearActiveWorkout(userId);
+    // Czyszczenie warunkowe (tylko gdy wskaźnik nadal == activeId), by nie
+    // nadpisać treningu, który równoległy createWorkout właśnie aktywował.
+    await workoutRepo.clearActiveWorkoutIfMatches(userId, activeId);
     return null;
   }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,8 @@
       "devDependencies": {
         "@eslint/js": "^9.39.1",
         "@tailwindcss/vite": "^4.1.18",
+        "@testing-library/dom": "10.4.0",
+        "@testing-library/react": "16.1.0",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
@@ -25,7 +27,9 @@
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
+        "fake-indexeddb": "6.0.0",
         "globals": "^16.5.0",
+        "jsdom": "25.0.1",
         "playwright": "^1.59.1",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.18",
@@ -34,6 +38,27 @@
         "vite": "^7.2.4",
         "vitest": "^4.1.6"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -269,6 +294,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -315,6 +350,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -1665,6 +1815,61 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.1.0.tgz",
+      "integrity": "sha512-Q2ToPvg0KsVL0ohND9A3zLJWcOXXcO8IDu3fj11KhNt0UlCWyFyvnCIBkd12tidB2lkiVRG8VFqdhcqhqnAQtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2198,6 +2403,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2213,6 +2428,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -2238,6 +2463,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2247,6 +2482,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.22",
@@ -2348,6 +2590,20 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2426,6 +2682,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2455,12 +2724,47 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2480,12 +2784,39 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -2495,6 +2826,28 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2518,12 +2871,74 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -2794,6 +3209,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fake-indexeddb": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.0.0.tgz",
+      "integrity": "sha512-YEboHE5VfopUclOck7LncgIqskAqnv4q0EWbYCaxKKjAvO93c+TJIaBuGy8CBFdbg9nKdpN3AuPRwVBJ4k7NrQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2884,6 +3309,23 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -2913,6 +3355,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2921,6 +3373,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob-parent": {
@@ -2949,6 +3440,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2966,6 +3470,48 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -2981,6 +3527,60 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -3043,6 +3643,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3078,6 +3685,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -3445,6 +4093,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3453,6 +4111,39 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -3517,6 +4208,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -3590,6 +4288,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -3732,6 +4443,34 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3762,6 +4501,13 @@
       "peerDependencies": {
         "react": "^19.2.3"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -3823,6 +4569,33 @@
         "@rollup/rollup-win32-x64-gnu": "4.53.3",
         "@rollup/rollup-win32-x64-msvc": "4.53.3",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -3921,6 +4694,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
@@ -3984,6 +4764,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4269,6 +5095,67 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4311,6 +5198,45 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,8 @@
   "devDependencies": {
     "@eslint/js": "^9.39.1",
     "@tailwindcss/vite": "^4.1.18",
+    "@testing-library/dom": "10.4.0",
+    "@testing-library/react": "16.1.0",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
@@ -29,7 +31,9 @@
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
+    "fake-indexeddb": "6.0.0",
     "globals": "^16.5.0",
+    "jsdom": "25.0.1",
     "playwright": "^1.59.1",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.18",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -309,8 +309,10 @@ function AuthenticatedApp({
       setIsWorkoutFormOpen(false);
       setSelectedWorkoutId(newWorkout.id);
       setScreen("workout-detail");
-    } catch {
+    } catch (error) {
       alert("Nie udało się utworzyć treningu");
+      // Rzuć dalej, by modal odblokował przycisk i pozwolił spróbować ponownie.
+      throw error;
     }
   };
 

--- a/frontend/src/components/modals/WorkoutFormModal.tsx
+++ b/frontend/src/components/modals/WorkoutFormModal.tsx
@@ -60,7 +60,11 @@ export function WorkoutFormModal({ onClose, onSubmit }: WorkoutFormModalProps) {
     e.preventDefault();
     if (isSubmitting) return;
     setIsSubmitting(true);
-    const dateObj = new Date(workoutDate);
+    // Parsuj YYYY-MM-DD w czasie LOKALNYM. `new Date("YYYY-MM-DD")` parsuje jako
+    // północ UTC, co po setHours/setMinutes (lokalne) potrafi przesunąć datę o
+    // dzień w strefach z ujemnym offsetem.
+    const [year, month, day] = workoutDate.split("-").map(Number);
+    const dateObj = new Date(year, month - 1, day);
     dateObj.setHours(new Date().getHours());
     dateObj.setMinutes(new Date().getMinutes());
     try {

--- a/frontend/src/components/modals/WorkoutFormModal.tsx
+++ b/frontend/src/components/modals/WorkoutFormModal.tsx
@@ -8,7 +8,7 @@ interface WorkoutFormModalProps {
     gymName?: string;
     workoutDate: string;
     workoutPlanId?: string;
-  }) => void;
+  }) => void | Promise<void>;
 }
 
 export function WorkoutFormModal({ onClose, onSubmit }: WorkoutFormModalProps) {
@@ -18,6 +18,7 @@ export function WorkoutFormModal({ onClose, onSubmit }: WorkoutFormModalProps) {
   const [workoutDate, setWorkoutDate] = useState(today);
   const [workoutPlanId, setWorkoutPlanId] = useState<string>("");
   const [planPickerOpen, setPlanPickerOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const planPickerRef = useRef<HTMLDivElement>(null);
 
   const { plans } = useData();
@@ -55,17 +56,24 @@ export function WorkoutFormModal({ onClose, onSubmit }: WorkoutFormModalProps) {
     return () => document.removeEventListener("mousedown", handler);
   }, [planPickerOpen]);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (isSubmitting) return;
+    setIsSubmitting(true);
     const dateObj = new Date(workoutDate);
     dateObj.setHours(new Date().getHours());
     dateObj.setMinutes(new Date().getMinutes());
-    onSubmit({
-      workoutName: workoutName.trim() || undefined,
-      gymName: gymName.trim() || undefined,
-      workoutDate: dateObj.toISOString(),
-      workoutPlanId: workoutPlanId || undefined,
-    });
+    try {
+      await onSubmit({
+        workoutName: workoutName.trim() || undefined,
+        gymName: gymName.trim() || undefined,
+        workoutDate: dateObj.toISOString(),
+        workoutPlanId: workoutPlanId || undefined,
+      });
+    } catch {
+      // Tworzenie nieudane — odblokuj przycisk, by user mógł spróbować ponownie.
+      setIsSubmitting(false);
+    }
   };
 
   const formattedDate = new Date(workoutDate).toLocaleDateString("pl-PL", {
@@ -314,26 +322,32 @@ export function WorkoutFormModal({ onClose, onSubmit }: WorkoutFormModalProps) {
             <button
               type="button"
               onClick={onClose}
+              disabled={isSubmitting}
               className="font-dm-sans font-bold text-[15px] rounded-[15px] cursor-pointer"
               style={{
                 padding: 15,
                 background: "var(--gg-surface2)",
                 border: "1.5px solid var(--gg-border)",
                 color: "var(--gg-text-sub)",
+                opacity: isSubmitting ? 0.5 : 1,
+                cursor: isSubmitting ? "not-allowed" : "pointer",
               }}
             >
               Anuluj
             </button>
             <button
               type="submit"
-              className="font-dm-sans font-bold text-[15px] rounded-[15px] cursor-pointer text-white border-none"
+              disabled={isSubmitting}
+              className="font-dm-sans font-bold text-[15px] rounded-[15px] text-white border-none"
               style={{
                 padding: 15,
                 background: "var(--gg-grad-btn)",
                 boxShadow: "0 4px 20px var(--gg-glow)",
+                opacity: isSubmitting ? 0.7 : 1,
+                cursor: isSubmitting ? "not-allowed" : "pointer",
               }}
             >
-              Rozpocznij →
+              {isSubmitting ? "Tworzenie…" : "Rozpocznij →"}
             </button>
           </div>
         </form>

--- a/frontend/src/contexts/DataContext.test.tsx
+++ b/frontend/src/contexts/DataContext.test.tsx
@@ -1,0 +1,288 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "fake-indexeddb/auto";
+import React from "react";
+import { renderHook, waitFor, act } from "@testing-library/react";
+
+// --- Mock collaborators -----------------------------------------------------
+vi.mock("../utils/syncManager", () => {
+  const syncManager = {
+    start: vi.fn(),
+    stop: vi.fn(),
+    onSync: vi.fn(() => () => {}),
+    onSyncFailure: vi.fn(() => () => {}),
+    onWorkoutNotFound: vi.fn(() => () => {}),
+    queueOperation: vi.fn(async () => "op-x"),
+    syncNow: vi.fn(async () => {}),
+    getIsOnline: vi.fn(() => true),
+  };
+  return { syncManager, default: syncManager };
+});
+
+vi.mock("../utils/auth", () => ({
+  authFetch: vi.fn(),
+  getAuthHeaders: vi.fn(() => ({ "Content-Type": "application/json" })),
+}));
+
+vi.mock("./AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: "u1", firstName: "T", lastName: "U", email: "t@e.com" },
+  }),
+}));
+
+import { DataProvider, useData } from "./DataContext";
+import { syncManager } from "../utils/syncManager";
+import { authFetch } from "../utils/auth";
+import { localStore } from "../utils/localStore";
+
+const mockedFetch = authFetch as unknown as ReturnType<typeof vi.fn>;
+const mockedSync = syncManager as unknown as Record<string, ReturnType<typeof vi.fn>>;
+
+const makeRes = (status: number, body: unknown = {}) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  clone: () => ({ json: async () => body }),
+  json: async () => body,
+});
+
+const isWorkoutPost = (url: unknown, opts: unknown) =>
+  String(url).endsWith("/api/workouts") &&
+  (opts as RequestInit | undefined)?.method === "POST";
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <DataProvider>{children}</DataProvider>
+);
+
+const renderData = async () => {
+  const hook = renderHook(() => useData(), { wrapper });
+  // Let the initial load / fetchAllFromServer settle.
+  await waitFor(() => expect(hook.result.current.isLoading).toBe(false));
+  return hook;
+};
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  await Promise.all([
+    localStore.clear("workouts"),
+    localStore.clear("exercises"),
+    localStore.clear("stats"),
+    localStore.clear("pendingSync"),
+    localStore.clear("metadata"),
+  ]);
+  // Default: every GET during initial load returns empty data.
+  mockedFetch.mockResolvedValue(makeRes(200, { data: [] }));
+  mockedSync.queueOperation.mockResolvedValue("op-x");
+});
+
+describe("DataContext.createWorkout", () => {
+  it("dedupes concurrent calls into a single POST (fixes triple-tap duplicates)", async () => {
+    // Deferred POST so both calls overlap before the first resolves.
+    let resolvePost: (v: unknown) => void = () => {};
+    const postPromise = new Promise((resolve) => {
+      resolvePost = resolve;
+    });
+
+    mockedFetch.mockImplementation((url: unknown, opts: unknown) => {
+      if (isWorkoutPost(url, opts)) return postPromise;
+      return Promise.resolve(makeRes(200, { data: [] }));
+    });
+
+    const { result } = await renderData();
+
+    let p1: Promise<unknown>, p2: Promise<unknown>;
+    await act(async () => {
+      // Fire two creates without awaiting — simulate rapid double tap.
+      p1 = result.current.createWorkout({ workoutName: "A" });
+      p2 = result.current.createWorkout({ workoutName: "B" });
+      // Now release the in-flight POST.
+      resolvePost(makeRes(201, { data: { id: "w-real", items: [], status: "DRAFT" } }));
+      await Promise.all([p1, p2]);
+    });
+
+    const postCalls = mockedFetch.mock.calls.filter(([url, opts]) =>
+      isWorkoutPost(url, opts),
+    );
+    expect(postCalls.length).toBe(1);
+  });
+
+  it("returns the same workout object to both concurrent callers", async () => {
+    mockedFetch.mockImplementation((url: unknown, opts: unknown) => {
+      if (isWorkoutPost(url, opts)) {
+        return Promise.resolve(
+          makeRes(201, { data: { id: "w-real", items: [], status: "DRAFT" } }),
+        );
+      }
+      return Promise.resolve(makeRes(200, { data: [] }));
+    });
+
+    const { result } = await renderData();
+
+    let r1: any, r2: any;
+    await act(async () => {
+      const [a, b] = await Promise.all([
+        result.current.createWorkout({ workoutName: "A" }),
+        result.current.createWorkout({ workoutName: "B" }),
+      ]);
+      r1 = a;
+      r2 = b;
+    });
+
+    expect(r1.id).toBe("w-real");
+    expect(r2.id).toBe("w-real");
+  });
+
+  it("offline create produces a temp workout and queues exactly one sync op", async () => {
+    mockedFetch.mockImplementation((url: unknown, opts: unknown) => {
+      if (isWorkoutPost(url, opts)) {
+        // Network failure → offline fallback path.
+        return Promise.reject(new TypeError("Failed to fetch"));
+      }
+      return Promise.resolve(makeRes(200, { data: [] }));
+    });
+
+    const { result } = await renderData();
+
+    let created: any;
+    await act(async () => {
+      created = await result.current.createWorkout({ workoutName: "Offline" });
+    });
+
+    expect(created.id).toMatch(/^temp_workout_/);
+    expect(created.status).toBe("DRAFT");
+
+    const createOps = mockedSync.queueOperation.mock.calls.filter(
+      ([op]) => op.entity === "workout" && op.type === "create",
+    );
+    expect(createOps.length).toBe(1);
+    expect(createOps[0][0].data).toEqual(
+      expect.objectContaining({ workoutName: "Offline", clientTempId: created.id }),
+    );
+  });
+
+  it("a second create after the first settles is allowed (guard resets)", async () => {
+    mockedFetch.mockImplementation((url: unknown, opts: unknown) => {
+      if (isWorkoutPost(url, opts)) {
+        return Promise.resolve(
+          makeRes(201, { data: { id: `w-${Math.random()}`, items: [], status: "DRAFT" } }),
+        );
+      }
+      return Promise.resolve(makeRes(200, { data: [] }));
+    });
+
+    const { result } = await renderData();
+
+    await act(async () => {
+      await result.current.createWorkout({ workoutName: "first" });
+    });
+    await act(async () => {
+      await result.current.createWorkout({ workoutName: "second" });
+    });
+
+    const postCalls = mockedFetch.mock.calls.filter(([url, opts]) =>
+      isWorkoutPost(url, opts),
+    );
+    // Two sequential (non-overlapping) creates => two POSTs.
+    expect(postCalls.length).toBe(2);
+  });
+});
+
+describe("DataContext.addSet 404 handling (data-loss fix)", () => {
+  const exercise = {
+    id: "e1",
+    name: "Squat",
+    muscleGroups: [],
+    description: undefined,
+    photos: [],
+    creator: { id: "u1", firstName: "T", lastName: "U", email: "t@e.com" },
+  };
+  const workout = {
+    id: "w1",
+    userId: "u1",
+    status: "DRAFT",
+    workoutDate: new Date().toISOString(),
+    workoutName: "W",
+    gymName: null,
+    location: null,
+    workoutNotes: null,
+    workoutPlanId: null,
+    skippedPlanExerciseIds: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    items: [
+      {
+        id: "i1",
+        workoutId: "w1",
+        exerciseId: "e1",
+        orderInWorkout: 1,
+        notes: null,
+        previousNote: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        exercise: { id: "e1", name: "Squat", muscleGroups: [], description: null, photos: [] },
+        sets: [],
+      },
+    ],
+  };
+
+  const installFetch = (onSetPost: () => Promise<unknown>) => {
+    mockedFetch.mockImplementation((url: unknown, opts: unknown) => {
+      const u = String(url);
+      const method = (opts as RequestInit | undefined)?.method ?? "GET";
+      if (method === "POST" && u.includes("/items/i1/sets")) return onSetPost();
+      if (u.endsWith("/api/workouts/active")) {
+        return Promise.resolve(makeRes(200, { data: { activeWorkoutId: "w1" } }));
+      }
+      if (u.endsWith("/api/workouts/w1")) {
+        return Promise.resolve(makeRes(200, { data: workout }));
+      }
+      if (u.endsWith("/api/workouts")) {
+        return Promise.resolve(makeRes(200, { data: [workout] }));
+      }
+      if (u.includes("/api/exercises")) {
+        return Promise.resolve(makeRes(200, { data: [exercise] }));
+      }
+      return Promise.resolve(makeRes(200, { data: [] }));
+    });
+  };
+
+  it("on set 404 reconciles the single workout (refreshWorkout) instead of purging it", async () => {
+    installFetch(() => Promise.resolve(makeRes(404, {})));
+
+    const { result } = await renderData();
+    await waitFor(() => expect(result.current.workouts.length).toBe(1));
+
+    await act(async () => {
+      await result.current.addSet("w1", "i1", { weight: 50, repetitions: 8, setNumber: 1 });
+    });
+
+    // Workout must NOT be purged from local state.
+    expect(result.current.workouts.find((w) => w.id === "w1")).toBeTruthy();
+
+    // A reconcile GET for that single workout must have been issued.
+    const refreshCalls = mockedFetch.mock.calls.filter(
+      ([url, opts]) =>
+        String(url).endsWith("/api/workouts/w1") &&
+        ((opts as RequestInit | undefined)?.method ?? "GET") === "GET",
+    );
+    expect(refreshCalls.length).toBeGreaterThanOrEqual(1);
+
+    // No sync op queued for a 404 set.
+    const setOps = mockedSync.queueOperation.mock.calls.filter(([op]) => op.entity === "set");
+    expect(setOps.length).toBe(0);
+  });
+
+  it("on set success the optimistic set is kept and no reconcile/queue happens", async () => {
+    installFetch(() => Promise.resolve(makeRes(201, { data: { id: "s-real" } })));
+
+    const { result } = await renderData();
+    await waitFor(() => expect(result.current.workouts.length).toBe(1));
+
+    await act(async () => {
+      await result.current.addSet("w1", "i1", { weight: 50, repetitions: 8, setNumber: 1 });
+    });
+
+    const w = result.current.workouts.find((x) => x.id === "w1");
+    expect(w?.items[0].sets.length).toBe(1);
+  });
+});
+

--- a/frontend/src/contexts/DataContext.tsx
+++ b/frontend/src/contexts/DataContext.tsx
@@ -1145,7 +1145,7 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
 
         if (result.data) {
           idMappingRef.current.set(tempItemId, result.data.id);
-          void localStore.addIdMappings({ [tempItemId]: result.data.id });
+          await localStore.addIdMappings({ [tempItemId]: result.data.id });
 
           let remappedWorkout: Workout | null = null;
           setWorkouts((prev) =>
@@ -1523,7 +1523,7 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
         const result = await response.json();
         if (result.data) {
           idMappingRef.current.set(tempSetId, result.data.id);
-          void localStore.addIdMappings({ [tempSetId]: result.data.id });
+          await localStore.addIdMappings({ [tempSetId]: result.data.id });
         }
         if (shouldRefreshStats) {
           await refreshStatsData();

--- a/frontend/src/contexts/DataContext.tsx
+++ b/frontend/src/contexts/DataContext.tsx
@@ -164,6 +164,11 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
   // Mapowanie tymczasowych ID na prawdziwe - nie powoduje re-renderów
   const idMappingRef = useRef<Map<string, string>>(new Map());
 
+  // Dedup równoległych/podwójnych wywołań createWorkout (np. potrójne tapnięcie
+  // przycisku "Rozpocznij" gdy sieć jest wolna). Dopóki trwa jedno tworzenie,
+  // kolejne wywołania zwracają ten sam promise zamiast tworzyć nowy trening.
+  const createWorkoutInFlightRef = useRef<Promise<Workout> | null>(null);
+
   const invalidateProgressionCache = useCallback(
     async (exerciseId?: string) => {
       const keysToDelete = Array.from(progressionCacheRef.current.keys()).filter(
@@ -499,6 +504,7 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
           localActiveId,
           syncTime,
           localPlans,
+          localIdMappings,
         ] = await Promise.all([
           localStore.getAll<Workout>("workouts"),
           localStore.getAll<Exercise>("exercises"),
@@ -507,7 +513,13 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
           localStore.getActiveWorkoutId(),
           localStore.getLastSync(),
           localStore.getAll<WorkoutPlan>("plans"),
+          localStore.getIdMappings(),
         ]);
+
+        // Odtwórz mapowania temp->real ID (przeżywają reload strony).
+        Object.entries(localIdMappings).forEach(([tempId, realId]) => {
+          idMappingRef.current.set(tempId, realId);
+        });
 
         setWorkouts(localWorkouts);
         setExercises(localExercises);
@@ -636,8 +648,14 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
       workoutDate?: string;
       workoutPlanId?: string;
     }) => {
-      try {
-        const response = await authFetch(`${API_BASE}/api/workouts`, {
+      // Jeśli tworzenie już trwa, zwróć ten sam promise (dedup podwójnego submitu).
+      if (createWorkoutInFlightRef.current) {
+        return createWorkoutInFlightRef.current;
+      }
+
+      const run = async (): Promise<Workout> => {
+        try {
+          const response = await authFetch(`${API_BASE}/api/workouts`, {
           method: "POST",
           headers: getAuthHeaders(),
           body: JSON.stringify(data),
@@ -699,6 +717,15 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
         });
 
         return tempWorkout;
+      }
+      };
+
+      const promise = run();
+      createWorkoutInFlightRef.current = promise;
+      try {
+        return await promise;
+      } finally {
+        createWorkoutInFlightRef.current = null;
       }
     },
     [isOfflineError, queueSyncOperation, user?.id, fetchAllFromServer],
@@ -1118,6 +1145,7 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
 
         if (result.data) {
           idMappingRef.current.set(tempItemId, result.data.id);
+          void localStore.addIdMappings({ [tempItemId]: result.data.id });
 
           let remappedWorkout: Workout | null = null;
           setWorkouts((prev) =>
@@ -1477,9 +1505,9 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
           },
         );
         if (response.status === 404) {
-          await purgeLocalWorkout(realWorkoutId);
-          alert("Ten trening nie istnieje już na serwerze — został usunięty z urządzenia.");
-          throw new WorkoutNotFoundError(`Workout ${realWorkoutId} no longer exists`);
+          // Item/seria nie istnieje na serwerze — pogódź TEN trening (nie kasuj całego).
+          await refreshWorkout(realWorkoutId);
+          return;
         }
         if (!response.ok) {
           await queueSyncOperation({
@@ -1495,6 +1523,7 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
         const result = await response.json();
         if (result.data) {
           idMappingRef.current.set(tempSetId, result.data.id);
+          void localStore.addIdMappings({ [tempSetId]: result.data.id });
         }
         if (shouldRefreshStats) {
           await refreshStatsData();
@@ -1539,7 +1568,7 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
         }
       }
     },
-    [invalidateProgressionCache, isOfflineError, purgeLocalWorkout, queueSyncOperation, refreshStatsData],
+    [invalidateProgressionCache, isOfflineError, queueSyncOperation, refreshStatsData, refreshWorkout],
   );
 
   const updateSet = useCallback(
@@ -1620,9 +1649,9 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
           body: JSON.stringify(data),
         });
         if (response.status === 404) {
-          await purgeLocalWorkout(realWorkoutId);
-          alert("Ten trening nie istnieje już na serwerze — został usunięty z urządzenia.");
-          throw new WorkoutNotFoundError(`Workout ${realWorkoutId} no longer exists`);
+          // Seria nie istnieje na serwerze — pogódź TEN trening (nie kasuj całego).
+          await refreshWorkout(realWorkoutId);
+          return;
         }
         if (!response.ok) {
           await queueSyncOperation({
@@ -1677,7 +1706,7 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
         }
       }
     },
-    [invalidateProgressionCache, isOfflineError, purgeLocalWorkout, queueSyncOperation, refreshStatsData],
+    [invalidateProgressionCache, isOfflineError, queueSyncOperation, refreshStatsData, refreshWorkout],
   );
 
   const deleteSet = useCallback(
@@ -1745,9 +1774,9 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
           method: "DELETE",
         });
         if (response.status === 404) {
-          await purgeLocalWorkout(realWorkoutId);
-          alert("Ten trening nie istnieje już na serwerze — został usunięty z urządzenia.");
-          throw new WorkoutNotFoundError(`Workout ${realWorkoutId} no longer exists`);
+          // Seria nie istnieje na serwerze — pogódź TEN trening (nie kasuj całego).
+          await refreshWorkout(realWorkoutId);
+          return;
         }
         if (!response.ok) {
           await queueSyncOperation({
@@ -1808,9 +1837,9 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
     [
       invalidateProgressionCache,
       isOfflineError,
-      purgeLocalWorkout,
       queueSyncOperation,
       refreshStatsData,
+      refreshWorkout,
       removePendingOperationsReferencingTempId,
     ],
   );

--- a/frontend/src/utils/localStore.test.ts
+++ b/frontend/src/utils/localStore.test.ts
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+// Provides a real, in-memory IndexedDB implementation for the test environment.
+import "fake-indexeddb/auto";
+import { IDBFactory } from "fake-indexeddb";
+
+import { localStore } from "./localStore";
+import type { SyncOperation } from "./localStore";
+
+// localStore caches the opened DB connection in a module-level variable, so we
+// cannot fully reset it per test. Instead we use unique keys per test where it
+// matters, and clear the relevant stores up front.
+beforeEach(async () => {
+  await Promise.all([
+    localStore.clear("workouts"),
+    localStore.clear("exercises"),
+    localStore.clear("stats"),
+    localStore.clear("pendingSync"),
+    localStore.clear("metadata"),
+  ]);
+});
+
+const makeSyncOp = (overrides: Partial<SyncOperation> = {}): Omit<SyncOperation, "id"> => ({
+  type: "create",
+  entity: "set",
+  endpoint: "/api/workouts/items/i1/sets",
+  method: "POST",
+  data: { weight: 50, repetitions: 8 },
+  timestamp: Date.now(),
+  retries: 0,
+  ...overrides,
+});
+
+describe("localStore", () => {
+  it("ensures fake-indexeddb is active", () => {
+    expect(indexedDB).toBeInstanceOf(IDBFactory);
+  });
+
+  describe("generic store CRUD", () => {
+    it("put + get + getAll + delete + clear round-trips records", async () => {
+      await localStore.put("workouts", { id: "w1", name: "A" });
+      await localStore.put("workouts", { id: "w2", name: "B" });
+
+      expect(await localStore.get("workouts", "w1")).toEqual({ id: "w1", name: "A" });
+      expect((await localStore.getAll("workouts")).length).toBe(2);
+
+      await localStore.delete("workouts", "w1");
+      expect(await localStore.get("workouts", "w1")).toBeNull();
+
+      await localStore.clear("workouts");
+      expect(await localStore.getAll("workouts")).toEqual([]);
+    });
+
+    it("get returns null for a missing key", async () => {
+      expect(await localStore.get("exercises", "nope")).toBeNull();
+    });
+
+    it("putMany writes all items atomically", async () => {
+      await localStore.putMany("exercises", [
+        { id: "e1", name: "Squat" },
+        { id: "e2", name: "Bench" },
+        { id: "e3", name: "Row" },
+      ]);
+      const all = await localStore.getAll<{ id: string }>("exercises");
+      expect(all.map((e) => e.id).sort()).toEqual(["e1", "e2", "e3"]);
+    });
+
+    it("put overwrites an existing record with the same id", async () => {
+      await localStore.put("workouts", { id: "w1", name: "old" });
+      await localStore.put("workouts", { id: "w1", name: "new" });
+      expect(await localStore.get("workouts", "w1")).toEqual({ id: "w1", name: "new" });
+    });
+  });
+
+  describe("pending sync queue", () => {
+    it("addPendingSync returns a unique id and stores the operation", async () => {
+      const id1 = await localStore.addPendingSync(makeSyncOp());
+      const id2 = await localStore.addPendingSync(makeSyncOp());
+
+      expect(id1).not.toBe(id2);
+      const ops = await localStore.getPendingSyncOperations();
+      expect(ops.length).toBe(2);
+      expect(ops.map((o) => o.id).sort()).toEqual([id1, id2].sort());
+    });
+
+    it("updatePendingSync mutates an existing operation (e.g. retry counter)", async () => {
+      const id = await localStore.addPendingSync(makeSyncOp({ retries: 0 }));
+      const [op] = await localStore.getPendingSyncOperations();
+      await localStore.updatePendingSync({ ...op, retries: 2 });
+
+      const [updated] = await localStore.getPendingSyncOperations();
+      expect(updated.retries).toBe(2);
+      expect(updated.id).toBe(id);
+    });
+
+    it("removePendingSync deletes the operation", async () => {
+      const id = await localStore.addPendingSync(makeSyncOp());
+      await localStore.removePendingSync(id);
+      expect(await localStore.getPendingSyncOperations()).toEqual([]);
+    });
+  });
+
+  describe("metadata + lastSync", () => {
+    it("setMetadata / getMetadata round-trip arbitrary values", async () => {
+      await localStore.setMetadata("statsOverview", { totalSets: 42 });
+      expect(await localStore.getMetadata("statsOverview")).toEqual({ totalSets: 42 });
+    });
+
+    it("getMetadata returns null when missing", async () => {
+      expect(await localStore.getMetadata("does-not-exist")).toBeNull();
+    });
+
+    it("getLastSync defaults to 0 and persists via setLastSync", async () => {
+      expect(await localStore.getLastSync()).toBe(0);
+      await localStore.setLastSync(123456);
+      expect(await localStore.getLastSync()).toBe(123456);
+    });
+  });
+
+  describe("active workout helper", () => {
+    it("defaults to null and round-trips a workout id", async () => {
+      await localStore.setActiveWorkoutId(null);
+      expect(await localStore.getActiveWorkoutId()).toBeNull();
+
+      await localStore.setActiveWorkoutId("w-active");
+      expect(await localStore.getActiveWorkoutId()).toBe("w-active");
+
+      await localStore.setActiveWorkoutId(null);
+      expect(await localStore.getActiveWorkoutId()).toBeNull();
+    });
+  });
+
+  describe("id mappings (temp -> real) — persistence of the offline-sync fix", () => {
+    it("getIdMappings defaults to an empty object", async () => {
+      expect(await localStore.getIdMappings()).toEqual({});
+    });
+
+    it("addIdMappings merges new entries with existing ones", async () => {
+      await localStore.addIdMappings({ temp_workout_1: "w-real" });
+      await localStore.addIdMappings({ temp_item_1: "i-real", temp_set_1: "s-real" });
+
+      expect(await localStore.getIdMappings()).toEqual({
+        temp_workout_1: "w-real",
+        temp_item_1: "i-real",
+        temp_set_1: "s-real",
+      });
+    });
+
+    it("addIdMappings overwrites a mapping for the same temp id", async () => {
+      await localStore.addIdMappings({ temp_x: "first" });
+      await localStore.addIdMappings({ temp_x: "second" });
+      expect((await localStore.getIdMappings()).temp_x).toBe("second");
+    });
+
+    it("addIdMappings with no entries is a no-op", async () => {
+      await localStore.addIdMappings({ temp_x: "v" });
+      await localStore.addIdMappings({});
+      expect(await localStore.getIdMappings()).toEqual({ temp_x: "v" });
+    });
+  });
+});

--- a/frontend/src/utils/localStore.ts
+++ b/frontend/src/utils/localStore.ts
@@ -221,6 +221,21 @@ export const localStore = {
     } as unknown as { id: string });
   },
 
+  // Trwałe mapowanie tymczasowych ID (temp_*) na prawdziwe ID z serwera.
+  // Musi przeżyć przeładowanie strony i kolejne przebiegi synchronizacji,
+  // inaczej operacje-dzieci (np. zapis serii) odwołujące się do temp-ID
+  // rodzica nigdy się nie rozwiążą i dane przepadają po cichu.
+  async getIdMappings(): Promise<Record<string, string>> {
+    return (await this.getMetadata<Record<string, string>>("idMappings")) ?? {};
+  },
+
+  async addIdMappings(entries: Record<string, string>): Promise<void> {
+    const keys = Object.keys(entries);
+    if (keys.length === 0) return;
+    const current = await this.getIdMappings();
+    await this.setMetadata("idMappings", { ...current, ...entries });
+  },
+
   // Active workout helper
   async getActiveWorkoutId(): Promise<string | null> {
     const data = await this.get<{ key: string; workoutId: string | null }>(

--- a/frontend/src/utils/syncManager.test.ts
+++ b/frontend/src/utils/syncManager.test.ts
@@ -1,0 +1,317 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks for the two collaborators of SyncManager -------------------------
+vi.mock("./localStore", () => {
+  const localStore = {
+    getPendingSyncOperations: vi.fn(),
+    getIdMappings: vi.fn(),
+    addIdMappings: vi.fn(),
+    addPendingSync: vi.fn(),
+    removePendingSync: vi.fn(),
+    updatePendingSync: vi.fn(),
+    setLastSync: vi.fn(),
+    setActiveWorkoutId: vi.fn(),
+    setMetadata: vi.fn(),
+    clear: vi.fn(),
+    putMany: vi.fn(),
+  };
+  return { localStore, default: localStore };
+});
+
+vi.mock("./auth", () => ({
+  authFetch: vi.fn(),
+  getAuthHeaders: vi.fn(() => ({ "Content-Type": "application/json" })),
+}));
+
+import { syncManager } from "./syncManager";
+import { localStore } from "./localStore";
+import { authFetch } from "./auth";
+import type { SyncOperation } from "./localStore";
+
+const mockedStore = localStore as unknown as Record<string, ReturnType<typeof vi.fn>>;
+const mockedFetch = authFetch as unknown as ReturnType<typeof vi.fn>;
+
+// Minimal fetch Response stand-in covering the surface SyncManager uses.
+const makeRes = (status: number, body: unknown = {}) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  clone: () => ({ json: async () => body }),
+  json: async () => body,
+});
+
+const baseOp = (overrides: Partial<SyncOperation> = {}): SyncOperation => ({
+  id: "op-1",
+  type: "create",
+  entity: "set",
+  endpoint: "/api/workouts/items/item-1/sets",
+  method: "POST",
+  data: { weight: 50, repetitions: 8, setNumber: 1 },
+  timestamp: 1,
+  retries: 0,
+  ...overrides,
+});
+
+// Parse the JSON body the SyncManager sent on its FIRST authFetch call.
+const sentBody = () => {
+  const firstCall = mockedFetch.mock.calls[0];
+  const init = firstCall?.[1] as RequestInit | undefined;
+  return init?.body ? JSON.parse(init.body as string) : null;
+};
+
+const sentUrl = () => mockedFetch.mock.calls[0]?.[0] as string | undefined;
+
+// Control connectivity WITHOUT dispatching window events — the "online" event
+// would trigger an extra background syncNow() that races with the test body.
+const setOnline = (value: boolean) => {
+  (syncManager as unknown as { isOnline: boolean }).isOnline = value;
+};
+
+describe("syncManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset internal state between tests (singleton).
+    (syncManager as unknown as { isOnline: boolean }).isOnline = true;
+    (syncManager as unknown as { isSyncing: boolean }).isSyncing = false;
+    // Sensible defaults — overridden per test.
+    mockedStore.getPendingSyncOperations.mockResolvedValue([]);
+    mockedStore.getIdMappings.mockResolvedValue({});
+    mockedStore.addIdMappings.mockResolvedValue(undefined);
+    mockedStore.addPendingSync.mockResolvedValue("op-generated");
+    mockedStore.removePendingSync.mockResolvedValue(undefined);
+    mockedStore.updatePendingSync.mockResolvedValue(undefined);
+    mockedStore.setLastSync.mockResolvedValue(undefined);
+    mockedStore.setActiveWorkoutId.mockResolvedValue(undefined);
+    mockedStore.setMetadata.mockResolvedValue(undefined);
+    mockedStore.clear.mockResolvedValue(undefined);
+    mockedStore.putMany.mockResolvedValue(undefined);
+    // Default response for fetchFreshData GETs.
+    mockedFetch.mockResolvedValue(makeRes(200, { data: null }));
+  });
+
+  it("resolves temp ids in endpoint and data, strips internal fields, captures + persists mapping, removes op", async () => {
+    mockedStore.getIdMappings.mockResolvedValue({ temp_item_1: "item-real" });
+    mockedStore.getPendingSyncOperations.mockResolvedValue([
+      baseOp({
+        endpoint: "/api/workouts/items/temp_item_1/sets",
+        data: {
+          weight: 50,
+          repetitions: 8,
+          setNumber: 1,
+          clientTempSetId: "temp_set_9",
+        },
+      }),
+    ]);
+    mockedFetch.mockResolvedValueOnce(makeRes(201, { data: { id: "set-real" } }));
+
+    await syncManager.syncNow();
+
+    // temp_item_1 resolved in the endpoint
+    expect(sentUrl()).toContain("/api/workouts/items/item-real/sets");
+    // internal client field stripped before hitting the API
+    expect(sentBody()).toEqual({ weight: 50, repetitions: 8, setNumber: 1 });
+    // captured set mapping persisted
+    expect(mockedStore.addIdMappings).toHaveBeenCalledWith({ temp_set_9: "set-real" });
+    // op removed after success
+    expect(mockedStore.removePendingSync).toHaveBeenCalledWith("op-1");
+  });
+
+  it("captures workout create mapping (clientTempId -> response.id)", async () => {
+    mockedStore.getPendingSyncOperations.mockResolvedValue([
+      baseOp({
+        entity: "workout",
+        endpoint: "/api/workouts",
+        data: { workoutName: "Push", clientTempId: "temp_workout_1" },
+      }),
+    ]);
+    mockedFetch.mockResolvedValueOnce(makeRes(201, { data: { id: "w-real" } }));
+
+    await syncManager.syncNow();
+
+    expect(sentBody()).toEqual({ workoutName: "Push" });
+    expect(mockedStore.addIdMappings).toHaveBeenCalledWith({ temp_workout_1: "w-real" });
+  });
+
+  it("captures set id from addExercise response shape (sets[0].id)", async () => {
+    mockedStore.getPendingSyncOperations.mockResolvedValue([
+      baseOp({
+        entity: "workoutItem",
+        endpoint: "/api/workouts/w1/exercises",
+        data: { exerciseId: "e1", clientTempItemId: "temp_item_5", clientTempSetId: "temp_set_5" },
+      }),
+    ]);
+    mockedFetch.mockResolvedValueOnce(
+      makeRes(201, { data: { id: "item-real", sets: [{ id: "set-real-0" }] } }),
+    );
+
+    await syncManager.syncNow();
+
+    expect(mockedStore.addIdMappings).toHaveBeenCalledWith(
+      expect.objectContaining({ temp_item_5: "item-real", temp_set_5: "set-real-0" }),
+    );
+  });
+
+  it("skips operations with unresolved temp ids without touching retries or removing them", async () => {
+    mockedStore.getPendingSyncOperations.mockResolvedValue([
+      baseOp({ endpoint: "/api/workouts/items/temp_item_unknown/sets" }),
+    ]);
+
+    await syncManager.syncNow();
+
+    // op POST must not be sent
+    const sentToSets = mockedFetch.mock.calls.some(([url]) =>
+      String(url).includes("temp_item_unknown"),
+    );
+    expect(sentToSets).toBe(false);
+    expect(mockedStore.removePendingSync).not.toHaveBeenCalled();
+    expect(mockedStore.updatePendingSync).not.toHaveBeenCalled();
+  });
+
+  it("workout 404 purges the workout (notifies workoutNotFound listener) and reports failure", async () => {
+    const onNotFound = vi.fn();
+    const onFailure = vi.fn();
+    const off1 = syncManager.onWorkoutNotFound(onNotFound);
+    const off2 = syncManager.onSyncFailure(onFailure);
+
+    mockedStore.getPendingSyncOperations.mockResolvedValue([
+      baseOp({ entity: "workout", endpoint: "/api/workouts/w1", method: "PATCH", workoutId: "w1" }),
+    ]);
+    mockedFetch.mockResolvedValueOnce(makeRes(404, {}));
+
+    await syncManager.syncNow();
+
+    expect(onNotFound).toHaveBeenCalledWith("w1");
+    expect(mockedStore.removePendingSync).toHaveBeenCalledWith("op-1");
+    expect(onFailure).toHaveBeenCalled();
+    off1();
+    off2();
+  });
+
+  it("set 404 does NOT purge the workout — only drops the op and reports failure", async () => {
+    const onNotFound = vi.fn();
+    const onFailure = vi.fn();
+    const off1 = syncManager.onWorkoutNotFound(onNotFound);
+    const off2 = syncManager.onSyncFailure(onFailure);
+
+    mockedStore.getPendingSyncOperations.mockResolvedValue([
+      baseOp({ entity: "set", workoutId: "w1" }),
+    ]);
+    mockedFetch.mockResolvedValueOnce(makeRes(404, {}));
+
+    await syncManager.syncNow();
+
+    expect(onNotFound).not.toHaveBeenCalled(); // workout preserved
+    expect(mockedStore.removePendingSync).toHaveBeenCalledWith("op-1");
+    expect(onFailure).toHaveBeenCalled();
+    off1();
+    off2();
+  });
+
+  it("workoutItem 404 does NOT purge the workout", async () => {
+    const onNotFound = vi.fn();
+    const off = syncManager.onWorkoutNotFound(onNotFound);
+
+    mockedStore.getPendingSyncOperations.mockResolvedValue([
+      baseOp({ entity: "workoutItem", endpoint: "/api/workouts/items/item-1", method: "DELETE", workoutId: "w1" }),
+    ]);
+    mockedFetch.mockResolvedValueOnce(makeRes(404, {}));
+
+    await syncManager.syncNow();
+
+    expect(onNotFound).not.toHaveBeenCalled();
+    expect(mockedStore.removePendingSync).toHaveBeenCalledWith("op-1");
+    off();
+  });
+
+  it("network error (TypeError) keeps the op and does NOT increment retries", async () => {
+    mockedStore.getPendingSyncOperations.mockResolvedValue([baseOp({ retries: 0 })]);
+    mockedFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+    await syncManager.syncNow();
+
+    expect(mockedStore.removePendingSync).not.toHaveBeenCalled();
+    expect(mockedStore.updatePendingSync).not.toHaveBeenCalled();
+  });
+
+  it("server error below MAX_RETRIES increments the retry counter", async () => {
+    mockedStore.getPendingSyncOperations.mockResolvedValue([baseOp({ retries: 1 })]);
+    mockedFetch.mockResolvedValueOnce(makeRes(500, {}));
+
+    await syncManager.syncNow();
+
+    expect(mockedStore.updatePendingSync).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "op-1", retries: 2 }),
+    );
+    expect(mockedStore.removePendingSync).not.toHaveBeenCalled();
+  });
+
+  it("server error at MAX_RETRIES drops the op and reports permanent failure", async () => {
+    const onFailure = vi.fn();
+    const off = syncManager.onSyncFailure(onFailure);
+
+    mockedStore.getPendingSyncOperations.mockResolvedValue([baseOp({ retries: 3 })]);
+    mockedFetch.mockResolvedValueOnce(makeRes(500, {}));
+
+    await syncManager.syncNow();
+
+    expect(mockedStore.removePendingSync).toHaveBeenCalledWith("op-1");
+    expect(onFailure).toHaveBeenCalled();
+    off();
+  });
+
+  it("does nothing while offline", async () => {
+    setOnline(false);
+
+    await syncManager.syncNow();
+
+    expect(mockedStore.getPendingSyncOperations).not.toHaveBeenCalled();
+  });
+
+  it("queueOperation persists the op via localStore.addPendingSync", async () => {
+    const id = await syncManager.queueOperation({
+      type: "create",
+      entity: "set",
+      endpoint: "/api/workouts/items/item-1/sets",
+      method: "POST",
+      data: { weight: 10, repetitions: 5, setNumber: 1 },
+    });
+
+    expect(mockedStore.addPendingSync).toHaveBeenCalledWith(
+      expect.objectContaining({ entity: "set", retries: 0 }),
+    );
+    expect(id).toBe("op-generated");
+  });
+
+  it("processes multiple ops in timestamp order so a parent create resolves a child reference", async () => {
+    mockedStore.getPendingSyncOperations.mockResolvedValue([
+      // child queued out of order (later in array but must run after parent)
+      baseOp({
+        id: "child",
+        entity: "set",
+        endpoint: "/api/workouts/items/temp_item_X/sets",
+        timestamp: 20,
+        data: { weight: 40, repetitions: 6, setNumber: 1 },
+      }),
+      baseOp({
+        id: "parent",
+        entity: "workoutItem",
+        endpoint: "/api/workouts/w1/exercises",
+        timestamp: 10,
+        data: { exerciseId: "e1", clientTempItemId: "temp_item_X" },
+      }),
+    ]);
+    // parent response first (sorted), then child
+    mockedFetch
+      .mockResolvedValueOnce(makeRes(201, { data: { id: "item-real-X" } }))
+      .mockResolvedValueOnce(makeRes(201, { data: { id: "set-real-X" } }));
+
+    await syncManager.syncNow();
+
+    const childUrl = mockedFetch.mock.calls.find(([url]) =>
+      String(url).includes("/sets"),
+    )?.[0];
+    expect(String(childUrl)).toContain("/api/workouts/items/item-real-X/sets");
+    expect(mockedStore.removePendingSync).toHaveBeenCalledWith("parent");
+    expect(mockedStore.removePendingSync).toHaveBeenCalledWith("child");
+  });
+});

--- a/frontend/src/utils/syncManager.ts
+++ b/frontend/src/utils/syncManager.ts
@@ -191,6 +191,14 @@ class SyncManager {
 
     if (operations.length === 0) return;
 
+    // Zasiej mapę trwałymi mapowaniami temp->real z poprzednich przebiegów/sesji.
+    // Bez tego operacja-dziecko (np. zapis serii) przetworzona w innym przebiegu
+    // niż jej rodzic nigdy nie rozwiąże temp-ID i przepadnie po cichu.
+    const persistedMappings = await localStore.getIdMappings();
+    for (const [tempId, realId] of Object.entries(persistedMappings)) {
+      tempIdMap.set(tempId, realId);
+    }
+
     console.log(
       `[SyncManager] Processing ${operations.length} pending operations`,
     );
@@ -239,10 +247,8 @@ class SyncManager {
           );
           await localStore.removePendingSync(op.id);
           console.log(`[SyncManager] Operation ${op.id} completed`);
-        } else if (
-          response.status === 404 &&
-          (op.entity === "workout" || op.entity === "workoutItem" || op.entity === "set")
-        ) {
+        } else if (response.status === 404 && op.entity === "workout") {
+          // Cały trening zniknął z serwera — usuń go lokalnie.
           await localStore.removePendingSync(op.id);
           permanentlyFailed.push({
             ...op,
@@ -255,7 +261,24 @@ class SyncManager {
           if (workoutId) {
             this.workoutNotFoundListeners.forEach((cb) => cb(workoutId));
           }
-          console.warn(`[SyncManager] Operation ${op.id} removed due to 404`);
+          console.warn(
+            `[SyncManager] Workout operation ${op.id} removed due to 404 (workout gone)`,
+          );
+        } else if (
+          response.status === 404 &&
+          (op.entity === "workoutItem" || op.entity === "set")
+        ) {
+          // Pojedynczy element (ćwiczenie w treningu / seria) nie istnieje na
+          // serwerze. NIE kasujemy całego treningu — porzucamy tylko tę operację.
+          // Pełny refetch (fetchFreshData) pogodzi stan po opróżnieniu kolejki.
+          await localStore.removePendingSync(op.id);
+          permanentlyFailed.push({
+            ...op,
+            failureReason: "not_found",
+          });
+          console.warn(
+            `[SyncManager] Item/set operation ${op.id} dropped due to 404 (workout preserved)`,
+          );
         } else if (op.retries < MAX_RETRIES) {
           // Zwiększ licznik prób
           await localStore.updatePendingSync({
@@ -299,9 +322,13 @@ class SyncManager {
   ): Promise<void> {
     if (!resolvedData || !isPlainObject(responseData)) return;
 
+    const newlyCaptured: Record<string, string> = {};
     const capture = (tempId: unknown, realId: unknown) => {
       if (typeof tempId === "string" && typeof realId === "string") {
         tempIdMap.set(tempId, realId);
+        if (tempId.startsWith("temp_")) {
+          newlyCaptured[tempId] = realId;
+        }
       }
     };
 
@@ -321,6 +348,11 @@ class SyncManager {
           ? (responseSets[0] as Record<string, unknown>).id
           : responseData.id;
       capture(resolvedData.clientTempSetId, realSetId);
+    }
+
+    // Utrwal mapowania, by przeżyły kolejne przebiegi sync i reload strony.
+    if (Object.keys(newlyCaptured).length > 0) {
+      await localStore.addIdMappings(newlyCaptured);
     }
   }
 


### PR DESCRIPTION
## Summary
Fixes three offline-sync defects reported from real usage: duplicate workouts from rapid taps, workouts that don't 'finish', and data that gets lost / reappears.

### Backend
- `createWorkout` is race-safe via a user row lock (`SELECT ... FOR UPDATE`) — rapid double/triple taps and parallel offline replays now reuse the active DRAFT instead of creating duplicates.
- `getActiveWorkoutId` self-heals a stale pointer to a COMPLETED/deleted workout, so a finished workout no longer comes back as 'in progress'.

### Frontend
- `DataContext.createWorkout` dedupes concurrent calls (in-flight promise); `WorkoutFormModal` disables submit while creating.
- A 404 on a set/item no longer purges the whole workout: `syncManager` drops only that op; the online path reconciles the single workout via `refreshWorkout`.
- temp→real id mappings are persisted in IndexedDB and seeded into both `DataContext` and `syncManager`, so child ops (e.g. saving a set) resolve across reloads and sync runs instead of being silently dropped.

## Tests
- Backend `workout.service`: 39 tests (race guard, self-heal, ownership, stats rebuilds). Total backend: **73 passing**.
- Frontend: `syncManager` (13), `localStore` (16, fake-indexeddb), `DataContext` (6). Total frontend: **47 passing**.
- Added dev tooling: jsdom, fake-indexeddb, @testing-library/react.

## Not covered by these tests
- Real DB-level race serialization (`FOR UPDATE`) needs a live Postgres; IndexedDB behavior on real mobile Safari. Suggest follow-up integration/e2e tests.