### PR TITLE
feat(sync): idempotent create operations via clientId

### DIFF
--- a/backend/prisma/migrations/20260716120000_add_client_id_idempotency/migration.sql
+++ b/backend/prisma/migrations/20260716120000_add_client_id_idempotency/migration.sql
@@ -1,0 +1,26 @@
+-- Idempotencja operacji create w offline-sync (retry po timeout/utracie odpowiedzi
+-- nie może tworzyć duplikatów treningów / ćwiczeń w treningu / serii).
+--
+-- Dodajemy nullable "clientId" wygenerowany po stronie klienta i unikalny klucz
+-- złożony (scope + clientId). Kolumny są NULL na wszystkich istniejących wierszach —
+-- brak backfillu, migracja jest czysto addytywna i bezpieczna na produkcji.
+-- W Postgresie NULL nie koliduje z innymi wartościami NULL w unique constraint,
+-- więc istniejące wiersze (clientId = NULL) nie wpływają na unikalność.
+
+-- AlterTable
+ALTER TABLE "workouts" ADD COLUMN "clientId" TEXT;
+
+-- AlterTable
+ALTER TABLE "workout_items" ADD COLUMN "clientId" TEXT;
+
+-- AlterTable
+ALTER TABLE "workout_sets" ADD COLUMN "clientId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "workouts_userId_clientId_key" ON "workouts"("userId", "clientId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "workout_items_workoutId_clientId_key" ON "workout_items"("workoutId", "clientId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "workout_sets_itemId_clientId_key" ON "workout_sets"("itemId", "clientId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -113,6 +113,9 @@ model Workout {
   durationSeconds        Int?
   workoutPlanId          String?
   skippedPlanExerciseIds String[]       @default([])
+  // ID wygenerowany po stronie klienta (offline-sync), używany do deduplikacji
+  // przy retry po timeout/utracie odpowiedzi. Nullable — nie backfillowany.
+  clientId               String?
   createdAt              DateTime       @default(now())
   updatedAt              DateTime       @updatedAt
 
@@ -121,6 +124,7 @@ model Workout {
   activeForUser User?         @relation("ActiveWorkout")
   plan          WorkoutPlan?  @relation(fields: [workoutPlanId], references: [id], onDelete: SetNull)
 
+  @@unique([userId, clientId])
   @@index([workoutPlanId])
   @@map("workouts")
 }
@@ -163,6 +167,9 @@ model WorkoutItem {
   orderInWorkout Int
   notes          String?
   previousNote   String?
+  // ID wygenerowany po stronie klienta (offline-sync), używany do deduplikacji
+  // przy retry po timeout/utracie odpowiedzi. Nullable — nie backfillowany.
+  clientId       String?
   createdAt      DateTime    @default(now())
   updatedAt      DateTime    @updatedAt
 
@@ -170,6 +177,7 @@ model WorkoutItem {
   exercise Exercise     @relation(fields: [exerciseId], references: [id], onDelete: Cascade)
   sets     WorkoutSet[]
 
+  @@unique([workoutId, clientId])
   @@map("workout_items")
 }
 
@@ -194,11 +202,15 @@ model WorkoutSet {
   setNumber   Int
   weight      Decimal  @db.Decimal(6, 2)
   repetitions Int
+  // ID wygenerowany po stronie klienta (offline-sync), używany do deduplikacji
+  // przy retry po timeout/utracie odpowiedzi. Nullable — nie backfillowany.
+  clientId    String?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
   item WorkoutItem @relation(fields: [itemId], references: [id], onDelete: Cascade)
 
+  @@unique([itemId, clientId])
   @@map("workout_sets")
 }
 

--- a/backend/src/modules/workout/API.md
+++ b/backend/src/modules/workout/API.md
@@ -17,7 +17,8 @@ Base URL: `/api/workouts`
   "gymName": "Gold's Gym", // optional
   "location": "Warszawa", // optional
   "workoutNotes": "Dobra forma dzisiaj", // optional
-  "workoutPlanId": "uuid" // optional, UUID widocznego planu (mine/builtin/community public)
+  "workoutPlanId": "uuid", // optional, UUID widocznego planu (mine/builtin/community public)
+  "clientId": "temp_workout_1700000000000" // optional, max 64 chars — see "Idempotency (clientId)" below
 }
 ```
 
@@ -155,7 +156,8 @@ Each stats entry may include `lastNote: null` if no note was saved on the latest
 {
   "exerciseId": "uuid",
   "orderInWorkout": 1, // optional, auto-increments
-  "notes": "Optional notes" // optional
+  "notes": "Optional notes", // optional
+  "clientId": "temp_item_1700000000000" // optional, max 64 chars — see "Idempotency (clientId)" below
 }
 ```
 
@@ -214,7 +216,8 @@ Each stats entry may include `lastNote: null` if no note was saved on the latest
 {
   "weight": 80.5,
   "repetitions": 10,
-  "setNumber": 2 // optional, auto-increments
+  "setNumber": 2, // optional, auto-increments
+  "clientId": "temp_set_1700000000000" // optional, max 64 chars — see "Idempotency (clientId)" below
 }
 ```
 
@@ -444,6 +447,20 @@ All values are calculated only from workouts with status `COMPLETED`.
    - System automatically updates stats and records
 7. **Delete workout (optional path):** `DELETE /api/workouts/:id`
    - System also removes nested workout items and sets.
+
+## Idempotency (clientId)
+
+Three "create" endpoints accept an optional `clientId` (string, max 64 chars) so that a retry after a timeout / lost response does not create a duplicate record:
+
+- `POST /api/workouts` — dedupe scope: `(userId, clientId)`
+- `POST /api/workouts/:workoutId/exercises` — dedupe scope: `(workoutId, clientId)`
+- `POST /api/workouts/items/:itemId/sets` — dedupe scope: `(itemId, clientId)`
+
+**Behavior:** if a record with the same `clientId` in the same scope already exists, the endpoint returns that existing record (same status code and shape as a normal create) instead of creating a new one. If two retries race concurrently, the database unique constraint on `(scope, clientId)` rejects the second insert and the server re-reads and returns the record the first one created — the caller never sees a duplicate or an error caused by the race.
+
+`clientId` is optional. Omitting it (e.g. calls that don't originate from the offline-sync queue) falls back to the previous create-always behavior — for workout creation this is still protected by the separate active-workout guard (a DRAFT workout is reused per user regardless of `clientId`).
+
+The frontend offline-sync queue (`syncManager.ts`) generates the id used here from the same temporary id (`temp_workout_*` / `temp_item_*` / `temp_set_*`) it already uses locally for optimistic UI updates, so no extra id needs to be tracked client-side.
 
 ## Error Responses
 

--- a/backend/src/modules/workout/workout.repository.ts
+++ b/backend/src/modules/workout/workout.repository.ts
@@ -52,7 +52,13 @@ const workoutInclude = {
  * ustawia activeWorkoutId, kolejne widzą już aktywny trening i go zwracają zamiast
  * tworzyć duplikat.
  *
- * @returns workout oraz flagę `reused` (true => zwrócono istniejący aktywny trening)
+ * Jeśli `data.clientId` jest ustawiony, dedupe po (userId, clientId) ma pierwszeństwo
+ * przed logiką aktywnego treningu — retry offline-sync po timeout/utracie odpowiedzi
+ * zawsze zwróci ten sam trening, niezależnie od tego, czy jest on nadal aktywny.
+ * Sprawdzenie odbywa się w tej samej transakcji co lock wiersza usera, więc jest
+ * odporne na wyścig równoległych retry.
+ *
+ * @returns workout oraz flagę `reused` (true => zwrócono istniejący rekord)
  */
 export const createWorkoutWithActiveGuard = async (
   userId: string,
@@ -61,6 +67,16 @@ export const createWorkoutWithActiveGuard = async (
   return prisma.$transaction(async (tx) => {
     // Lock wiersza użytkownika — serializuje równoległe tworzenie treningu.
     await tx.$queryRaw`SELECT id FROM "users" WHERE id = ${userId} FOR UPDATE`;
+
+    if (data.clientId) {
+      const existingByClientId = await tx.workout.findUnique({
+        where: { userId_clientId: { userId, clientId: data.clientId } },
+        include: workoutInclude,
+      });
+      if (existingByClientId) {
+        return { workout: existingByClientId, reused: true };
+      }
+    }
 
     const user = await tx.user.findUnique({
       where: { id: userId },
@@ -93,6 +109,13 @@ export const createWorkoutWithActiveGuard = async (
 };
 
 type WorkoutWithItems = Prisma.WorkoutGetPayload<{ include: typeof workoutInclude }>;
+
+export const findWorkoutByClientId = (userId: string, clientId: string) => {
+  return prisma.workout.findUnique({
+    where: { userId_clientId: { userId, clientId } },
+    include: workoutInclude,
+  });
+};
 
 export const findWorkoutById = (id: string) => {
   return prisma.workout.findUnique({
@@ -199,14 +222,36 @@ export const addExerciseToWorkout = (
   });
 };
 
+// Jeśli `clientId` jest ustawiony, dedupe po (workoutId, clientId) ma pierwszeństwo —
+// retry offline-sync po timeout/utracie odpowiedzi zwraca ten sam item zamiast
+// tworzyć duplikat. Wyścig równoległych retry (dwie transakcje jednocześnie widzą
+// "brak rekordu") kończy się P2002 na unikalnym kluczu — obsługiwane w service.
 export const addExerciseToWorkoutWithPendingNote = (
   workoutId: string,
   userId: string,
   exerciseId: string,
   orderInWorkout: number,
   notes?: string,
+  clientId?: string,
 ) => {
   return prisma.$transaction(async (tx) => {
+    if (clientId) {
+      const existingByClientId = await tx.workoutItem.findUnique({
+        where: { workoutId_clientId: { workoutId, clientId } },
+        include: {
+          exercise: {
+            include: {
+              photos: true,
+            },
+          },
+          sets: true,
+        },
+      });
+      if (existingByClientId) {
+        return existingByClientId;
+      }
+    }
+
     const pendingNote = await tx.exercisePendingNote.findUnique({
       where: {
         userId_exerciseId: {
@@ -226,6 +271,7 @@ export const addExerciseToWorkoutWithPendingNote = (
         orderInWorkout,
         notes: notes ?? null,
         previousNote: pendingNote?.note ?? null,
+        clientId: clientId ?? null,
       },
       include: {
         exercise: {
@@ -249,6 +295,18 @@ export const addExerciseToWorkoutWithPendingNote = (
     }
 
     return createdItem;
+  });
+};
+
+export const findWorkoutItemByClientId = (workoutId: string, clientId: string) => {
+  return prisma.workoutItem.findUnique({
+    where: { workoutId_clientId: { workoutId, clientId } },
+    include: {
+      exercise: true,
+      sets: {
+        orderBy: { setNumber: "asc" },
+      },
+    },
   });
 };
 
@@ -294,11 +352,15 @@ export const getMaxOrderInWorkout = async (
   return result._max.orderInWorkout || 0;
 };
 
+// Jeśli `clientId` jest ustawiony i wystąpi wyścig równoległych retry offline-sync,
+// create() rzuci P2002 na unikalnym kluczu (itemId, clientId) — obsługiwane w service
+// przez odczyt istniejącego rekordu (findWorkoutSetByClientId).
 export const addSetToWorkoutItem = (
   itemId: string,
   weight: number,
   repetitions: number,
-  setNumber: number
+  setNumber: number,
+  clientId?: string,
 ) => {
   return prisma.workoutSet.create({
     data: {
@@ -306,7 +368,14 @@ export const addSetToWorkoutItem = (
       weight,
       repetitions,
       setNumber,
+      clientId: clientId ?? null,
     },
+  });
+};
+
+export const findWorkoutSetByClientId = (itemId: string, clientId: string) => {
+  return prisma.workoutSet.findUnique({
+    where: { itemId_clientId: { itemId, clientId } },
   });
 };
 

--- a/backend/src/modules/workout/workout.schema.ts
+++ b/backend/src/modules/workout/workout.schema.ts
@@ -7,6 +7,9 @@ const createWorkoutBody = z.object({
   location: z.string().optional(),
   workoutNotes: z.string().optional(),
   workoutPlanId: z.string().uuid().optional(),
+  // ID wygenerowany po stronie klienta (offline-sync) — używany do deduplikacji
+  // przy retry po timeout/utracie odpowiedzi.
+  clientId: z.string().max(64).optional(),
 });
 
 export const createWorkoutSchema = z.object({
@@ -31,6 +34,9 @@ const addExerciseToWorkoutBody = z.object({
   exerciseId: z.string().uuid(),
   orderInWorkout: z.number().int().positive().optional(),
   notes: z.string().optional(),
+  // ID wygenerowany po stronie klienta (offline-sync) — używany do deduplikacji
+  // przy retry po timeout/utracie odpowiedzi.
+  clientId: z.string().max(64).optional(),
 });
 
 export const addExerciseToWorkoutSchema = z.object({
@@ -56,6 +62,9 @@ const createWorkoutSetBody = z.object({
   weight: z.number().positive(),
   repetitions: z.number().int().positive(),
   setNumber: z.number().int().positive().optional(),
+  // ID wygenerowany po stronie klienta (offline-sync) — używany do deduplikacji
+  // przy retry po timeout/utracie odpowiedzi.
+  clientId: z.string().max(64).optional(),
 });
 
 export const createWorkoutSetSchema = z.object({

--- a/backend/src/modules/workout/workout.service.test.ts
+++ b/backend/src/modules/workout/workout.service.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Prisma } from "@prisma/client";
 import * as workoutService from "./workout.service.js";
 import * as workoutRepo from "./workout.repository.js";
 
@@ -36,6 +37,9 @@ vi.mock("./workout.repository.js", () => ({
   setSkippedPlanExerciseIds: vi.fn(),
   findWorkoutStatus: vi.fn(),
   clearActiveWorkoutIfMatches: vi.fn(),
+  findWorkoutByClientId: vi.fn(),
+  findWorkoutItemByClientId: vi.fn(),
+  findWorkoutSetByClientId: vi.fn(),
 }));
 
 describe("workout.service", () => {
@@ -80,6 +84,54 @@ describe("workout.service", () => {
     );
     expect(workoutRepo.createWorkout).not.toHaveBeenCalled();
     expect(result).toEqual({ id: "w-new", userId: "u1", status: "DRAFT" });
+  });
+
+  it("createWorkout: dedupes by clientId — returns existing workout without hitting the active-workout guard twice", async () => {
+    vi.mocked(workoutRepo.createWorkoutWithActiveGuard).mockResolvedValue({
+      workout: { id: "w1", userId: "u1", status: "DRAFT", clientId: "temp_workout_1" } as any,
+      reused: true,
+    });
+
+    const result = await workoutService.createWorkout("u1", {
+      clientId: "temp_workout_1",
+    });
+
+    expect(workoutRepo.createWorkoutWithActiveGuard).toHaveBeenCalledWith(
+      "u1",
+      expect.objectContaining({ clientId: "temp_workout_1" }),
+    );
+    expect(result).toEqual({
+      id: "w1",
+      userId: "u1",
+      status: "DRAFT",
+      clientId: "temp_workout_1",
+    });
+  });
+
+  it("createWorkout: on P2002 race for clientId, returns the record the concurrent retry created", async () => {
+    const prismaError = Object.assign(
+      new Error("Unique constraint failed"),
+      { code: "P2002", name: "PrismaClientKnownRequestError" },
+    );
+    Object.setPrototypeOf(prismaError, Prisma.PrismaClientKnownRequestError.prototype);
+
+    vi.mocked(workoutRepo.createWorkoutWithActiveGuard).mockRejectedValue(prismaError);
+    vi.mocked(workoutRepo.findWorkoutByClientId).mockResolvedValue({
+      id: "w-existing",
+      userId: "u1",
+      clientId: "temp_workout_1",
+    } as any);
+
+    const result = await workoutService.createWorkout("u1", {
+      clientId: "temp_workout_1",
+    });
+
+    expect(workoutRepo.findWorkoutByClientId).toHaveBeenCalledWith("u1", "temp_workout_1");
+    expect(result).toEqual({
+      id: "w-existing",
+      userId: "u1",
+      clientId: "temp_workout_1",
+    });
   });
 
   it("getWorkoutById: throws when workout belongs to another user", async () => {
@@ -275,9 +327,69 @@ describe("workout.service", () => {
       "e1",
       3,
       undefined,
+      undefined,
     );
     expect(workoutRepo.addSetToWorkoutItem).not.toHaveBeenCalled();
     expect(result).toEqual({ id: "item-1", workoutId: "w1" });
+  });
+
+  it("addExerciseToWorkout: passes clientId to the repository and returns the created item", async () => {
+    vi.mocked(workoutRepo.findWorkoutById).mockResolvedValue({
+      id: "w1",
+      userId: "u1",
+    } as any);
+    vi.mocked(workoutRepo.getMaxOrderInWorkout).mockResolvedValue(0);
+    vi.mocked(workoutRepo.addExerciseToWorkoutWithPendingNote).mockResolvedValue({
+      id: "item-1",
+    } as any);
+    vi.mocked(workoutRepo.findWorkoutItemById).mockResolvedValue({
+      id: "item-1",
+      workoutId: "w1",
+    } as any);
+
+    await workoutService.addExerciseToWorkout("w1", "u1", {
+      exerciseId: "e1",
+      clientId: "temp_item_1",
+    });
+
+    expect(workoutRepo.addExerciseToWorkoutWithPendingNote).toHaveBeenCalledWith(
+      "w1",
+      "u1",
+      "e1",
+      1,
+      undefined,
+      "temp_item_1",
+    );
+  });
+
+  it("addExerciseToWorkout: on P2002 race for clientId, returns the item the concurrent retry created", async () => {
+    const prismaError = Object.assign(
+      new Error("Unique constraint failed"),
+      { code: "P2002", name: "PrismaClientKnownRequestError" },
+    );
+    Object.setPrototypeOf(prismaError, Prisma.PrismaClientKnownRequestError.prototype);
+
+    vi.mocked(workoutRepo.findWorkoutById).mockResolvedValue({
+      id: "w1",
+      userId: "u1",
+    } as any);
+    vi.mocked(workoutRepo.getMaxOrderInWorkout).mockResolvedValue(0);
+    vi.mocked(workoutRepo.addExerciseToWorkoutWithPendingNote).mockRejectedValue(prismaError);
+    vi.mocked(workoutRepo.findWorkoutItemByClientId).mockResolvedValue({
+      id: "item-existing",
+      workoutId: "w1",
+    } as any);
+
+    const result = await workoutService.addExerciseToWorkout("w1", "u1", {
+      exerciseId: "e1",
+      clientId: "temp_item_1",
+    });
+
+    expect(workoutRepo.findWorkoutItemByClientId).toHaveBeenCalledWith("w1", "temp_item_1");
+    expect(result).toEqual({ id: "item-existing", workoutId: "w1" });
+    // Retry musi zwrócić istniejący rekord bez tworzenia drugiego (findWorkoutItemById
+    // by wywołało kolejny fetch — sprawdzamy, że nie jest to droga sukcesu).
+    expect(workoutRepo.findWorkoutItemById).not.toHaveBeenCalled();
   });
 
   it("updateWorkoutItem: recalculates stats after note change in completed workout", async () => {
@@ -416,6 +528,7 @@ describe("workout.service", () => {
       60,
       8,
       5,
+      undefined,
     );
     expect(result).toEqual({ id: "set-5", setNumber: 5 });
   });
@@ -463,6 +576,62 @@ describe("workout.service", () => {
       totalWorkouts: 1,
       lastNote: null,
     });
+  });
+
+  it("addSetToWorkoutItem: dedupes by clientId — returns existing set without creating a new one", async () => {
+    vi.mocked(workoutRepo.findWorkoutItemById).mockResolvedValue({
+      id: "item-1",
+      workoutId: "w1",
+    } as any);
+    vi.mocked(workoutRepo.findWorkoutById).mockResolvedValue({
+      id: "w1",
+      userId: "u1",
+    } as any);
+    vi.mocked(workoutRepo.findWorkoutSetByClientId).mockResolvedValue({
+      id: "set-existing",
+      itemId: "item-1",
+    } as any);
+
+    const result = await workoutService.addSetToWorkoutItem("item-1", "u1", {
+      weight: 60,
+      repetitions: 8,
+      clientId: "temp_set_1",
+    });
+
+    expect(workoutRepo.findWorkoutSetByClientId).toHaveBeenCalledWith("item-1", "temp_set_1");
+    expect(workoutRepo.addSetToWorkoutItem).not.toHaveBeenCalled();
+    expect(workoutRepo.getMaxSetNumber).not.toHaveBeenCalled();
+    expect(result).toEqual({ id: "set-existing", itemId: "item-1" });
+  });
+
+  it("addSetToWorkoutItem: on P2002 race for clientId, returns the set the concurrent retry created", async () => {
+    const prismaError = Object.assign(
+      new Error("Unique constraint failed"),
+      { code: "P2002", name: "PrismaClientKnownRequestError" },
+    );
+    Object.setPrototypeOf(prismaError, Prisma.PrismaClientKnownRequestError.prototype);
+
+    vi.mocked(workoutRepo.findWorkoutItemById).mockResolvedValue({
+      id: "item-1",
+      workoutId: "w1",
+    } as any);
+    vi.mocked(workoutRepo.findWorkoutById).mockResolvedValue({
+      id: "w1",
+      userId: "u1",
+    } as any);
+    vi.mocked(workoutRepo.findWorkoutSetByClientId)
+      .mockResolvedValueOnce(null) // pierwszy pre-check: brak rekordu
+      .mockResolvedValueOnce({ id: "set-existing", itemId: "item-1" } as any); // po P2002
+    vi.mocked(workoutRepo.getMaxSetNumber).mockResolvedValue(0);
+    vi.mocked(workoutRepo.addSetToWorkoutItem).mockRejectedValue(prismaError);
+
+    const result = await workoutService.addSetToWorkoutItem("item-1", "u1", {
+      weight: 60,
+      repetitions: 8,
+      clientId: "temp_set_1",
+    });
+
+    expect(result).toEqual({ id: "set-existing", itemId: "item-1" });
   });
 
   it("updateWorkoutSet: recalculates stats for completed workouts", async () => {

--- a/backend/src/modules/workout/workout.service.ts
+++ b/backend/src/modules/workout/workout.service.ts
@@ -19,6 +19,12 @@ import {
 
 type StatsProgressMetric = "maxSetWeight" | "volume";
 
+// P2002 = naruszenie unikalnego klucza (Prisma). Używane do wykrycia wyścigu
+// równoległych retry offline-sync na (scope, clientId) — po złapaniu wyjątku
+// odczytujemy istniejący rekord zamiast propagować błąd do klienta.
+const isUniqueConstraintViolation = (error: unknown): boolean =>
+  error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002";
+
 export const createWorkout = async (userId: string, data: CreateWorkoutDto) => {
   if (data.workoutPlanId) {
     // Throws NotFoundError gdy plan nie istnieje lub nie jest widoczny dla usera.
@@ -36,16 +42,27 @@ export const createWorkout = async (userId: string, data: CreateWorkoutDto) => {
     ...(data.workoutPlanId && {
       plan: { connect: { id: data.workoutPlanId } },
     }),
+    ...(data.clientId && { clientId: data.clientId }),
   };
 
-  // Odporne na wyścig: lock wiersza usera serializuje równoległe żądania, więc
-  // potrójne tapnięcie / równoległy sync nie tworzy zduplikowanych treningów.
-  const { workout } = await workoutRepo.createWorkoutWithActiveGuard(
-    userId,
-    workoutData,
-  );
+  try {
+    // Odporne na wyścig: lock wiersza usera serializuje równoległe żądania, więc
+    // potrójne tapnięcie / równoległy sync nie tworzy zduplikowanych treningów.
+    // Dedupe po clientId (jeśli podany) ma pierwszeństwo nad logiką aktywnego
+    // treningu — patrz komentarz w createWorkoutWithActiveGuard.
+    const { workout } = await workoutRepo.createWorkoutWithActiveGuard(
+      userId,
+      workoutData,
+    );
 
-  return workout;
+    return workout;
+  } catch (error) {
+    if (data.clientId && isUniqueConstraintViolation(error)) {
+      const existing = await workoutRepo.findWorkoutByClientId(userId, data.clientId);
+      if (existing) return existing;
+    }
+    throw error;
+  }
 };
 
 export const getWorkoutById = async (id: string, userId: string) => {
@@ -149,13 +166,26 @@ export const addExerciseToWorkout = async (
     orderInWorkout = maxOrder + 1;
   }
 
-  const item = await workoutRepo.addExerciseToWorkoutWithPendingNote(
-    workoutId,
-    userId,
-    data.exerciseId,
-    orderInWorkout,
-    data.notes
-  );
+  let item;
+  try {
+    item = await workoutRepo.addExerciseToWorkoutWithPendingNote(
+      workoutId,
+      userId,
+      data.exerciseId,
+      orderInWorkout,
+      data.notes,
+      data.clientId,
+    );
+  } catch (error) {
+    if (data.clientId && isUniqueConstraintViolation(error)) {
+      const existing = await workoutRepo.findWorkoutItemByClientId(
+        workoutId,
+        data.clientId,
+      );
+      if (existing) return existing;
+    }
+    throw error;
+  }
 
   if (workout.status === "COMPLETED") {
     await rebuildExerciseStatsFromCompletedWorkouts(userId, data.exerciseId);
@@ -230,15 +260,30 @@ export const addSetToWorkoutItem = async (
     throw new Error("Brak uprawnień");
   }
 
+  if (data.clientId) {
+    const existing = await workoutRepo.findWorkoutSetByClientId(itemId, data.clientId);
+    if (existing) return existing;
+  }
+
   const maxSetNumber = await workoutRepo.getMaxSetNumber(itemId);
   const setNumber = maxSetNumber + 1;
 
-  const createdSet = await workoutRepo.addSetToWorkoutItem(
-    itemId,
-    data.weight,
-    data.repetitions,
-    setNumber
-  );
+  let createdSet;
+  try {
+    createdSet = await workoutRepo.addSetToWorkoutItem(
+      itemId,
+      data.weight,
+      data.repetitions,
+      setNumber,
+      data.clientId,
+    );
+  } catch (error) {
+    if (data.clientId && isUniqueConstraintViolation(error)) {
+      const existing = await workoutRepo.findWorkoutSetByClientId(itemId, data.clientId);
+      if (existing) return existing;
+    }
+    throw error;
+  }
 
   if (workout.status === "COMPLETED") {
     await rebuildExerciseStatsFromCompletedWorkouts(userId, item.exerciseId);

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -413,6 +413,14 @@ paths:
                 gymName: { type: string }
                 location: { type: string }
                 workoutNotes: { type: string }
+                workoutPlanId: { type: string, format: uuid }
+                clientId:
+                  type: string
+                  maxLength: 64
+                  description: >-
+                    Opcjonalny ID wygenerowany po stronie klienta (offline-sync).
+                    Dedupe po (userId, clientId) — retry po timeout/utracie
+                    odpowiedzi zwraca istniejący trening zamiast tworzyć duplikat.
       responses:
         "201":
           description: Utworzony trening
@@ -521,6 +529,13 @@ paths:
                 exerciseId: { type: string, format: uuid }
                 orderInWorkout: { type: integer }
                 notes: { type: string }
+                clientId:
+                  type: string
+                  maxLength: 64
+                  description: >-
+                    Opcjonalny ID wygenerowany po stronie klienta (offline-sync).
+                    Dedupe po (workoutId, clientId) — retry po timeout/utracie
+                    odpowiedzi zwraca istniejący item zamiast tworzyć duplikat.
       responses:
         "201":
           description: WorkoutItem z pierwszą serią
@@ -585,6 +600,13 @@ paths:
                 weight: { type: number, minimum: 0 }
                 repetitions: { type: integer, minimum: 1 }
                 setNumber: { type: integer }
+                clientId:
+                  type: string
+                  maxLength: 64
+                  description: >-
+                    Opcjonalny ID wygenerowany po stronie klienta (offline-sync).
+                    Dedupe po (itemId, clientId) — retry po timeout/utracie
+                    odpowiedzi zwraca istniejącą serię zamiast tworzyć duplikat.
       responses:
         "201":
           description: Dodana seria

--- a/frontend/src/contexts/DataContext.test.tsx
+++ b/frontend/src/contexts/DataContext.test.tsx
@@ -284,5 +284,88 @@ describe("DataContext.addSet 404 handling (data-loss fix)", () => {
     const w = result.current.workouts.find((x) => x.id === "w1");
     expect(w?.items[0].sets.length).toBe(1);
   });
+
+  it("addSet sends clientId matching the optimistic temp set id (backend idempotency)", async () => {
+    installFetch(() => Promise.resolve(makeRes(201, { data: { id: "s-real" } })));
+
+    const { result } = await renderData();
+    await waitFor(() => expect(result.current.workouts.length).toBe(1));
+
+    await act(async () => {
+      await result.current.addSet("w1", "i1", { weight: 50, repetitions: 8, setNumber: 1 });
+    });
+
+    const setPostCall = mockedFetch.mock.calls.find(
+      ([url, opts]) =>
+        String(url).includes("/items/i1/sets") &&
+        (opts as RequestInit | undefined)?.method === "POST",
+    );
+    const sentBody = JSON.parse((setPostCall?.[1] as RequestInit).body as string);
+    expect(sentBody.clientId).toMatch(/^temp_set_/);
+  });
+});
+
+describe("DataContext.addExerciseToWorkout", () => {
+  const exercise = {
+    id: "e1",
+    name: "Squat",
+    muscleGroups: [],
+    description: undefined,
+    photos: [],
+    creator: { id: "u1", firstName: "T", lastName: "U", email: "t@e.com" },
+  };
+  const workout = {
+    id: "w1",
+    userId: "u1",
+    status: "DRAFT",
+    workoutDate: new Date().toISOString(),
+    workoutName: "W",
+    gymName: null,
+    location: null,
+    workoutNotes: null,
+    workoutPlanId: null,
+    skippedPlanExerciseIds: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    items: [],
+  };
+
+  it("sends clientId matching the optimistic temp item id (backend idempotency)", async () => {
+    mockedFetch.mockImplementation((url: unknown, opts: unknown) => {
+      const u = String(url);
+      const method = (opts as RequestInit | undefined)?.method ?? "GET";
+      if (method === "POST" && u.endsWith("/api/workouts/w1/exercises")) {
+        return Promise.resolve(makeRes(201, { data: { id: "item-real", sets: [] } }));
+      }
+      if (u.endsWith("/api/workouts/active")) {
+        return Promise.resolve(makeRes(200, { data: { activeWorkoutId: "w1" } }));
+      }
+      if (u.endsWith("/api/workouts/w1")) {
+        return Promise.resolve(makeRes(200, { data: workout }));
+      }
+      if (u.endsWith("/api/workouts")) {
+        return Promise.resolve(makeRes(200, { data: [workout] }));
+      }
+      if (u.includes("/api/exercises")) {
+        return Promise.resolve(makeRes(200, { data: [exercise] }));
+      }
+      return Promise.resolve(makeRes(200, { data: [] }));
+    });
+
+    const { result } = await renderData();
+    await waitFor(() => expect(result.current.workouts.length).toBe(1));
+
+    await act(async () => {
+      await result.current.addExerciseToWorkout("w1", "e1");
+    });
+
+    const postCall = mockedFetch.mock.calls.find(
+      ([url, opts]) =>
+        String(url).endsWith("/api/workouts/w1/exercises") &&
+        (opts as RequestInit | undefined)?.method === "POST",
+    );
+    const sentBody = JSON.parse((postCall?.[1] as RequestInit).body as string);
+    expect(sentBody).toEqual({ exerciseId: "e1", clientId: expect.stringMatching(/^temp_item_/) });
+  });
 });
 

--- a/frontend/src/contexts/DataContext.tsx
+++ b/frontend/src/contexts/DataContext.tsx
@@ -1141,7 +1141,7 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
           {
             method: "POST",
             headers: getAuthHeaders(),
-            body: JSON.stringify({ exerciseId }),
+            body: JSON.stringify({ exerciseId, clientId: tempItemId }),
           },
         );
         if (response.status === 404) {
@@ -1459,7 +1459,7 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
           {
             method: "POST",
             headers: getAuthHeaders(),
-            body: JSON.stringify(data),
+            body: JSON.stringify({ ...data, clientId: tempSetId }),
           },
         );
         if (response.status === 404) {

--- a/frontend/src/utils/syncManager.test.ts
+++ b/frontend/src/utils/syncManager.test.ts
@@ -89,7 +89,7 @@ describe("syncManager", () => {
     mockedFetch.mockResolvedValue(makeRes(200, { data: null }));
   });
 
-  it("resolves temp ids in endpoint and data, strips internal fields, captures + persists mapping, removes op", async () => {
+  it("resolves temp ids in endpoint and data, maps internal field to clientId, captures + persists mapping, removes op", async () => {
     mockedStore.getIdMappings.mockResolvedValue({ temp_item_1: "item-real" });
     mockedStore.getPendingSyncOperations.mockResolvedValue([
       baseOp({
@@ -108,15 +108,20 @@ describe("syncManager", () => {
 
     // temp_item_1 resolved in the endpoint
     expect(sentUrl()).toContain("/api/workouts/items/item-real/sets");
-    // internal client field stripped before hitting the API
-    expect(sentBody()).toEqual({ weight: 50, repetitions: 8, setNumber: 1 });
+    // internal client field mapped to clientId (for backend dedupe) before hitting the API
+    expect(sentBody()).toEqual({
+      weight: 50,
+      repetitions: 8,
+      setNumber: 1,
+      clientId: "temp_set_9",
+    });
     // captured set mapping persisted
     expect(mockedStore.addIdMappings).toHaveBeenCalledWith({ temp_set_9: "set-real" });
     // op removed after success
     expect(mockedStore.removePendingSync).toHaveBeenCalledWith("op-1");
   });
 
-  it("captures workout create mapping (clientTempId -> response.id)", async () => {
+  it("captures workout create mapping (clientTempId -> response.id) and forwards it as clientId", async () => {
     mockedStore.getPendingSyncOperations.mockResolvedValue([
       baseOp({
         entity: "workout",
@@ -128,8 +133,23 @@ describe("syncManager", () => {
 
     await syncManager.syncNow();
 
-    expect(sentBody()).toEqual({ workoutName: "Push" });
+    expect(sentBody()).toEqual({ workoutName: "Push", clientId: "temp_workout_1" });
     expect(mockedStore.addIdMappings).toHaveBeenCalledWith({ temp_workout_1: "w-real" });
+  });
+
+  it("maps clientTempItemId to clientId for addExerciseToWorkout retries", async () => {
+    mockedStore.getPendingSyncOperations.mockResolvedValue([
+      baseOp({
+        entity: "workoutItem",
+        endpoint: "/api/workouts/w1/exercises",
+        data: { exerciseId: "e1", clientTempItemId: "temp_item_5" },
+      }),
+    ]);
+    mockedFetch.mockResolvedValueOnce(makeRes(201, { data: { id: "item-real" } }));
+
+    await syncManager.syncNow();
+
+    expect(sentBody()).toEqual({ exerciseId: "e1", clientId: "temp_item_5" });
   });
 
   it("captures set id from addExercise response shape (sets[0].id)", async () => {

--- a/frontend/src/utils/syncManager.ts
+++ b/frontend/src/utils/syncManager.ts
@@ -63,17 +63,57 @@ const hasUnresolvedTempIds = (value: unknown): boolean => {
   return false;
 };
 
-const INTERNAL_SYNC_FIELDS = new Set([
-  "clientTempId",
-  "clientTempItemId",
-  "clientTempSetId",
-]);
+// Kolejność ma znaczenie tylko dla czytelności — dla każdej operacji "create" co
+// najwyżej jedno z tych pól jest obecne w danych (odpowiada temu, co tworzy dana
+// operacja: trening / ćwiczenie / seria). Wszystkie mapują się na to samo pole
+// `clientId` po stronie backendu, który dedupikuje po (scope, clientId) — dzięki
+// temu retry po timeout/utracie odpowiedzi nie tworzy duplikatu.
+const INTERNAL_SYNC_FIELDS = ["clientTempId", "clientTempItemId", "clientTempSetId"] as const;
 
-const stripInternalSyncFields = (
+/**
+ * Zamienia wewnętrzne pola śledzenia temp-ID (clientTempId / clientTempItemId /
+ * clientTempSetId) na pojedyncze pole `clientId` wysyłane do backendu. Backend
+ * używa go do deduplikacji operacji create — bez tego retry (np. po timeout, gdy
+ * odpowiedź serwera zginęła) tworzyłby duplikat treningu/ćwiczenia/serii.
+ * Dla operacji innych niż create (update/delete) pola te i tak nie występują
+ * w danych, więc payload wraca bez zmian.
+ */
+const mapInternalSyncFieldsToClientId = (
+  payload: Record<string, unknown>,
+): Record<string, unknown> => {
+  const result: Record<string, unknown> = {};
+  let clientId: unknown;
+
+  for (const [key, value] of Object.entries(payload)) {
+    if ((INTERNAL_SYNC_FIELDS as readonly string[]).includes(key)) {
+      clientId = value;
+      continue;
+    }
+    result[key] = value;
+  }
+
+  if (typeof clientId === "string") {
+    result.clientId = clientId;
+  }
+
+  return result;
+};
+
+/**
+ * Usuwa wewnętrzne pola śledzenia temp-ID bez zamiany na `clientId`. Używane
+ * WYŁĄCZNIE do sprawdzenia hasUnresolvedTempIds: wartość clientTempItemId /
+ * clientTempSetId / clientTempId to zawsze temp-ID *tworzonego właśnie* rekordu
+ * (nie referencja do cudzego rodzica), więc pasuje do TEMP_ID_PATTERN i fałszywie
+ * wyglądałoby na nierozwiązane odwołanie, gdyby zostało w payloadzie pod tym
+ * sprawdzeniem — także po przemapowaniu na `clientId` (ta sama wartość string).
+ */
+const omitInternalSyncFields = (
   payload: Record<string, unknown>,
 ): Record<string, unknown> =>
   Object.fromEntries(
-    Object.entries(payload).filter(([key]) => !INTERNAL_SYNC_FIELDS.has(key)),
+    Object.entries(payload).filter(
+      ([key]) => !(INTERNAL_SYNC_FIELDS as readonly string[]).includes(key),
+    ),
   );
 
 class SyncManager {
@@ -210,16 +250,24 @@ class SyncManager {
       try {
         const resolvedEndpoint = replaceTempIdsInString(op.endpoint, tempIdMap);
         const resolvedData = replaceTempIdsDeep(op.data, tempIdMap);
-        const apiData = isPlainObject(resolvedData)
-          ? stripInternalSyncFields(resolvedData)
+
+        // Sprawdzenie nierozwiązanych temp-ID musi pominąć wewnętrzne pola —
+        // ich wartość to zawsze temp-ID tworzonego właśnie rekordu (pasuje do
+        // wzorca temp_*), nie odwołanie do rodzica czekające na rozwiązanie.
+        const dataForUnresolvedCheck = isPlainObject(resolvedData)
+          ? omitInternalSyncFields(resolvedData)
           : resolvedData;
 
         if (
           hasUnresolvedTempIds(resolvedEndpoint) ||
-          hasUnresolvedTempIds(apiData)
+          hasUnresolvedTempIds(dataForUnresolvedCheck)
         ) {
           continue;
         }
+
+        const apiData = isPlainObject(resolvedData)
+          ? mapInternalSyncFieldsToClientId(resolvedData)
+          : resolvedData;
 
         const fetchOptions: RequestInit = {
           method: op.method,


### PR DESCRIPTION
## Summary
Retries after a timeout / lost response could create duplicate workouts, workout items, and sets (typical at the gym: request reaches the server, the response is lost, sync retries). The server had no way to recognize a retried create — `syncManager` stripped the client temp ids before sending.

## Changes
**Backend**
- Prisma: nullable `clientId` on `Workout`/`WorkoutItem`/`WorkoutSet` + composite unique (`userId`/`workoutId`/`itemId` + `clientId`). Purely additive migration, no backfill — safe on production (verified by applying it to a restored copy of the production backup).
- Zod schemas accept optional `clientId` (max 64) on the three create endpoints.
- Repository/service: create paths dedupe by `clientId` (pre-check + `P2002` race fallback returns the existing record).
- Docs: `workout/API.md` + `openapi.yaml`.

**Frontend**
- `syncManager`: `clientTempId`/`clientTempItemId`/`clientTempSetId` are now mapped to `clientId` in the outgoing body instead of stripped.
- `DataContext`: online paths of `addExerciseToWorkout`/`addSet` send `clientId` equal to the optimistic temp id.

## Tested
- Backend: 46 tests ✓ (6 new dedupe/race tests), `tsc` ✓
- Frontend: 22 tests ✓ (3 new), `tsc` ✓
- Migration dry-run against a restored production backup (Docker postgres:17): 3× ALTER, 3× unique index, existing rows unaffected ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)